### PR TITLE
[REFACTOR] 사원정보 버전 관리 기능 추가

### DIFF
--- a/src/main/java/com/example/chulgunhazabackend/domain/member/Employee.java
+++ b/src/main/java/com/example/chulgunhazabackend/domain/member/Employee.java
@@ -18,6 +18,7 @@ import java.util.List;
     }
 )
 @Getter
+@ToString
 public class Employee extends BaseEntity {
 
     @Id
@@ -25,6 +26,9 @@ public class Employee extends BaseEntity {
     @SequenceGenerator(name = "employee_seq_gen", sequenceName = "employee_seq", allocationSize = 1)
     @Column(name = "employee_id")
     private Long id;
+
+    @Version
+    private long version;
 
     @Column(nullable = false)
     private String name;
@@ -110,6 +114,11 @@ public class Employee extends BaseEntity {
 
     public void updateAnnual(Annual annual){
         this.annual = annual;
+    }
+
+
+    public boolean matchVersion(long version){
+        return this.version == version;
     }
 
 

--- a/src/main/java/com/example/chulgunhazabackend/dto/Employee/EmployeeModifyRequestDto.java
+++ b/src/main/java/com/example/chulgunhazabackend/dto/Employee/EmployeeModifyRequestDto.java
@@ -42,5 +42,7 @@ public class EmployeeModifyRequestDto {
     @NotNull(message = "권한을 입력해야 합니다.")
     private List<UserRole> userRoleList; // 권한
 
+    @NotNull
+    private long version; // 버전
 
 }

--- a/src/main/java/com/example/chulgunhazabackend/dto/Employee/EmployeeResponseDto.java
+++ b/src/main/java/com/example/chulgunhazabackend/dto/Employee/EmployeeResponseDto.java
@@ -31,11 +31,13 @@ public class EmployeeResponseDto {
 
     private Annual annual;
 
+    private long version;
+
     public static EmployeeResponseDto fromEntity(Employee employee){
         return new EmployeeResponseDto(
                 employee.getId(), employee.getName(), employee.getEmail(),
                 employee.getEmployeeImage(), employee.getGender(), employee.getDepartment(),
-                employee.getPosition(), employee.getUserRoleList(), employee.getAnnual()
+                employee.getPosition(), employee.getUserRoleList(), employee.getAnnual(), employee.getVersion()
         );
     }
 }

--- a/src/main/java/com/example/chulgunhazabackend/exception/employeeException/EmployeeExceptionType.java
+++ b/src/main/java/com/example/chulgunhazabackend/exception/employeeException/EmployeeExceptionType.java
@@ -5,7 +5,9 @@ import lombok.Getter;
 @Getter
 public enum EmployeeExceptionType {
     ALREADY_EXIST_EMAIL(404,"이미 존재하는 이메일입니다."),
-    NOT_EXIST_USER(404, "존재하지 않는 사원입니다.");
+    NOT_EXIST_USER(404, "존재하지 않는 사원입니다."),
+    ALREADY_CHANGED(404, "사원 정보가 다른 사용자에 의해 변경되었습니다.")
+    ;
 
     EmployeeExceptionType(int status, String message) {
         this.status = status;

--- a/src/main/java/com/example/chulgunhazabackend/repository/EmployeeRepository.java
+++ b/src/main/java/com/example/chulgunhazabackend/repository/EmployeeRepository.java
@@ -27,7 +27,7 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({
-            @QueryHint(name = "javax.persistence.lock.timeout", value = "3000")
+            @QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")
     })
     @Query("SELECT e FROM Employee e WHERE e.id = :employeeId")
     Optional<Employee> findEmployeeByIdForUpdate(@Param("employeeId") Long employeeId);


### PR DESCRIPTION
## #️⃣연관된 이슈
#5 

## 📝작업 내용
![image](https://github.com/user-attachments/assets/c99a4a0e-f401-40d4-a55b-b5b509ce712c)
![image](https://github.com/user-attachments/assets/2d99cd25-63e7-4a5f-8b62-872abcbcdc7b)

* 사원 정보 버전 관리 기능을 추가하였습니다. 
* update 쿼리가 성공한 경우 하이버네이트에서 자동으로 version 값을 1 증가시킵니다. 

![image](https://github.com/user-attachments/assets/2212a8a9-435d-4e95-9982-854d139ade4b)

* update한 version 값을 즉시 확인하기 위해서 JPA save() 대신 saveAndFlush()를 사용하였습니다.
* 그 외 이메일 체크 메서드를 수정하였습니다.
