### PR TITLE
[REFACTOR] 사원 정보 수정, 삭제 권한 체크 기능 추가

### DIFF
--- a/src/main/java/com/example/chulgunhazabackend/controller/EmployeeController.java
+++ b/src/main/java/com/example/chulgunhazabackend/controller/EmployeeController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -25,10 +26,12 @@ public class EmployeeController {
 
     // 사원 생성
     @PostMapping("/create")
+    @PreAuthorize("hasAnyRole('ROLE_MANAGER')")
     public ResponseEntity<?> create(
-            @Valid @RequestBody EmployeeCreateRequestDto employeeCreateRequestDto
-    ) throws IOException {
-        return ResponseEntity.status(201).body(employeeService.create(employeeCreateRequestDto));
+            @Valid @RequestBody EmployeeCreateRequestDto employeeCreateRequestDto,
+            @AuthenticationPrincipal EmployeeCredentialDto employeeCredentialDto) throws IOException {
+        return ResponseEntity.status(201).body(employeeService.create(employeeCreateRequestDto,
+                employeeCredentialDto.getEmployeeNo()));
     }
 
     // 사원 목록 조회
@@ -47,19 +50,23 @@ public class EmployeeController {
 
     // 사원 정보 수정 => 현재 로그인한 유저와 정보 일치하지 않으면 수정 불가
     @PutMapping("/modify/{employeeId}")
+    @PreAuthorize("hasAnyRole('ROLE_MANAGER')")
     public ResponseEntity<?> modifyEmployee(@PathVariable Long employeeId,
                                             @Valid @RequestPart EmployeeModifyRequestDto employeeModifyRequestDto,
-                                            @RequestParam(value = "employeeImage", required = false) MultipartFile employeeImage
+                                            @RequestParam(value = "employeeImage", required = false) MultipartFile employeeImage,
+                                            @AuthenticationPrincipal EmployeeCredentialDto employeeCredentialDto
                                             ) throws IOException {
 
         return ResponseEntity.status(200).body(
-                employeeService.modifyById(employeeId, employeeModifyRequestDto, employeeImage)
+                employeeService.modifyById(employeeId, employeeModifyRequestDto,
+                        employeeImage, employeeCredentialDto.getEmployeeNo())
         );
 
     }
 
     // 사원 삭제
     @PatchMapping("/delete/{employeeId}")
+    @PreAuthorize("hasAnyRole('ROLE_MANAGER')")
     public ResponseEntity<?> deleteEmployee(@PathVariable Long employeeId){
         return ResponseEntity.status(200).body(employeeService.deleteById(employeeId));
     }

--- a/src/main/java/com/example/chulgunhazabackend/event/common/Event.java
+++ b/src/main/java/com/example/chulgunhazabackend/event/common/Event.java
@@ -11,12 +11,10 @@ public abstract class Event {
     // 진행자 사원번호
     private final Long employeeNumber;
 
-    // 대상 사원번호
-    private final Long target;
 
-    public Event(Long target, Long employeeNumber) {
+
+    public Event(Long employeeNumber) {
         this.timestamp = System.currentTimeMillis();
-        this.target = target;
         this.employeeNumber = employeeNumber;
     }
 }

--- a/src/main/java/com/example/chulgunhazabackend/event/employee/event/EmployeeCreateEvent.java
+++ b/src/main/java/com/example/chulgunhazabackend/event/employee/event/EmployeeCreateEvent.java
@@ -9,8 +9,8 @@ import lombok.ToString;
 public class EmployeeCreateEvent extends Event {
 
     private final String message;
-    public EmployeeCreateEvent(Long target, Long employeeNumber) {
-        super(target, employeeNumber);
-        this.message = target + " 사원이 생성되었습니다.";
+    public EmployeeCreateEvent(Long employeeNumber) {
+        super(employeeNumber);
+        this.message = " 사원이 생성되었습니다.";
     }
 }

--- a/src/main/java/com/example/chulgunhazabackend/event/employee/event/EmployeeModifyEvent.java
+++ b/src/main/java/com/example/chulgunhazabackend/event/employee/event/EmployeeModifyEvent.java
@@ -12,8 +12,8 @@ public class EmployeeModifyEvent extends Event {
     // 이벤트 메세지
     private final String message;
 
-    public EmployeeModifyEvent(Long target, Long host) {
-        super(target, host);
-        this.message = target + "님의 정보가 수정되었습니다.";
+    public EmployeeModifyEvent(Long host) {
+        super(host);
+        this.message = "사원 정보가 수정되었습니다.";
     }
 }

--- a/src/main/java/com/example/chulgunhazabackend/service/EmployeeService.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/EmployeeService.java
@@ -12,14 +12,14 @@ import java.io.IOException;
 
 public interface EmployeeService {
 
-    Long create(EmployeeCreateRequestDto employeeCreateRequestDto) throws IOException;
+    Long create(EmployeeCreateRequestDto employeeCreateRequestDto, Long executor) throws IOException;
 
     PageDto<?> getEmployeeList(Pageable pageable);
 
     EmployeeResponseDto getEmployee(Long id);
 
     EmployeeResponseDto modifyById(Long id, EmployeeModifyRequestDto employeeModifyRequestDto,
-                                   MultipartFile image) throws IOException;
+                                   MultipartFile image, Long executor) throws IOException;
     Long deleteById(Long id);
 
 }

--- a/src/main/java/com/example/chulgunhazabackend/service/impl/EmployeeServiceImpl.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/impl/EmployeeServiceImpl.java
@@ -42,8 +42,9 @@ public class EmployeeServiceImpl implements EmployeeService {
 
     // 사원 최초 생성 시 기본이미지, 기본 연차 생성
 
-    public Long create(EmployeeCreateRequestDto employeeCreateRequestDto) throws IOException{
-        Events.raise(new EmployeeCreateEvent(1L, 10124024L)); // 대상자, 진행하는 사람
+    public Long create(EmployeeCreateRequestDto employeeCreateRequestDto, Long executor) throws IOException{
+
+        Events.raise(new EmployeeCreateEvent(executor)); //진행하는 사람
         checkEmail(employeeCreateRequestDto.getEmail());
         EmployeeImage employeeImage = EmployeeImage.builder()
                 .imageName("default image")
@@ -80,8 +81,8 @@ public class EmployeeServiceImpl implements EmployeeService {
     // TODO: 사원 파일 이미지 저장 서비스 추가 예정
     @Transactional(rollbackFor = IOException.class)
     public EmployeeResponseDto modifyById(Long id, EmployeeModifyRequestDto employeeModifyRequestDto,
-                                          MultipartFile image) throws IOException {
-        Events.raise(new EmployeeModifyEvent(1L, 10124024L));
+                                          MultipartFile image, Long executor) throws IOException {
+        Events.raise(new EmployeeModifyEvent(executor));
 
         Employee findEmployee = employeeRepository.findEmployeeByIdForUpdate(id).orElseThrow(()
                 -> new EmployeeException(EmployeeExceptionType.NOT_EXIST_USER));


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #5 

## 📝작업 내용
* 사원 정보 수정, 삭제의 경우 근태 관리자만 관리할 수 있도록 @PreAuthorize를 추가하여 권한 체크 기능을 추가하였습니다. 
![image](https://github.com/user-attachments/assets/e429e831-5599-4697-b7f0-0953eb7fda1f)

