### PR TITLE
[FEAT] #33 Complete

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,12 @@ dependencies {
     implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // rabbitMQ
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
+    // serialize
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
     // gson
     implementation 'com.google.code.gson:gson:2.10.1'
 

--- a/src/main/java/com/example/chulgunhazabackend/config/AsyncConfig.java
+++ b/src/main/java/com/example/chulgunhazabackend/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package com.example.chulgunhazabackend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+
+    // HACK: 우선 간단한 비동기 설정, 추후 논의 후에 다시 처리 필요.
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(3);
+        taskExecutor.setMaxPoolSize(10);
+        taskExecutor.setQueueCapacity(50);
+        taskExecutor.setThreadNamePrefix("async-thread-");
+        taskExecutor.initialize();
+        return taskExecutor;
+    }
+}

--- a/src/main/java/com/example/chulgunhazabackend/config/RabbitMQConfig.java
+++ b/src/main/java/com/example/chulgunhazabackend/config/RabbitMQConfig.java
@@ -1,0 +1,103 @@
+package com.example.chulgunhazabackend.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+@EnableRabbit
+public class RabbitMQConfig {
+
+    // INFO: Domain Queue
+    private static final String CHAT_QUEUE_NAME = "chulgunhazabackend_chat_queue";
+    private static final String MAIN_QUEUE_NAME = "chulgunhazabackend_record_queue";
+
+    // INFO: Notification Queue
+    private static final String CHAT_NOTIFICATION_QUEUE_NAME = "chulgunhazabackend_notification_queue";
+    private static final String MAIN_NOTIFICATION_QUEUE_NAME = "chulgunhazabackend_record_notification_queue";
+
+
+    // INFO: Exchange
+    private static final String CHAT_EXCHANGE_NAME = "chulgunhazabackend_chat";
+    private static final String MAIN_EXCHANGE_NAME = "chulgunhazabackend_main";
+
+    // INFO: Routing Key
+    private static final String CHAT_ROUTING_KEY = "chat_queue_key";
+    private static final String CHAT_NOTIFICATION_ROUTING_KEY = "chat_notification_queue_key";
+    private static final String MAIN_ROUTING_KEY = "main_queue_key";
+    private static final String MAIN_NOTIFICATION_ROUTING_KEY = "main_notification_queue_key";
+
+
+    @Bean
+    public Queue chatQueue() {
+        return new Queue(CHAT_QUEUE_NAME,true);
+    }
+
+    @Bean
+    public Queue chatNotificationQueue() {
+        return new Queue(CHAT_NOTIFICATION_QUEUE_NAME,true);
+    }
+
+    @Bean
+    public Queue mainQueue() {
+        return new Queue(MAIN_QUEUE_NAME,true);
+    }
+
+    @Bean
+    public Queue mainNotificationQueue() {
+        return new Queue(MAIN_NOTIFICATION_QUEUE_NAME,true);
+    }
+
+    @Bean
+    public DirectExchange chatExchange() {
+        return new DirectExchange(CHAT_EXCHANGE_NAME);
+    }
+
+    @Bean
+    public DirectExchange mainExchange() {
+        return new DirectExchange(MAIN_EXCHANGE_NAME);
+    }
+
+    @Bean
+    public Binding chatBinding() {
+        return BindingBuilder.bind(chatQueue()).to(chatExchange()).with(CHAT_ROUTING_KEY);
+    }
+
+    @Bean
+    public Binding chatNotificationBinding() {
+        return BindingBuilder.bind(chatNotificationQueue()).to(chatExchange()).with(CHAT_NOTIFICATION_ROUTING_KEY);
+    }
+
+    @Bean
+    public Binding mainBinding() {
+        return BindingBuilder.bind(mainQueue()).to(mainExchange()).with(MAIN_ROUTING_KEY);
+    }
+
+    @Bean
+    public Binding mainNotificationBinding() {
+        return BindingBuilder.bind(mainNotificationQueue()).to(mainExchange()).with(MAIN_NOTIFICATION_ROUTING_KEY);
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(new Jackson2JsonMessageConverter());
+        return rabbitTemplate;
+    }
+
+    // JSON 변환기
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+}

--- a/src/main/java/com/example/chulgunhazabackend/controller/NotificationController.java
+++ b/src/main/java/com/example/chulgunhazabackend/controller/NotificationController.java
@@ -1,0 +1,30 @@
+package com.example.chulgunhazabackend.controller;
+
+
+import com.example.chulgunhazabackend.service.ChatAlarmService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController{
+
+    private final ChatAlarmService chatAlarmService;
+
+    @GetMapping(value ="/subscribe/chat/{employeeNo}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribeChat(@PathVariable Long employeeNo) throws IOException {
+        return chatAlarmService.subscribe(employeeNo);
+    }
+
+    //TODO: MAIN Controller 생성
+
+}

--- a/src/main/java/com/example/chulgunhazabackend/dto/chat/ChatNotificationDto.java
+++ b/src/main/java/com/example/chulgunhazabackend/dto/chat/ChatNotificationDto.java
@@ -1,0 +1,27 @@
+package com.example.chulgunhazabackend.dto.chat;
+
+import com.example.chulgunhazabackend.domain.member.Position;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatNotificationDto implements Serializable {
+
+    public Long employeeNo;
+
+    public String name;
+
+    public String department;
+
+    public Position position;
+
+    public String message;
+
+    // TODO: 채팅 방 찾는 링크 추가
+
+}

--- a/src/main/java/com/example/chulgunhazabackend/listener/NotificationListener.java
+++ b/src/main/java/com/example/chulgunhazabackend/listener/NotificationListener.java
@@ -1,0 +1,25 @@
+package com.example.chulgunhazabackend.listener;
+
+import com.example.chulgunhazabackend.dto.chat.ChatNotificationDto;
+import com.example.chulgunhazabackend.service.ChatAlarmService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationListener {
+
+    private final ChatAlarmService chatAlarmService;
+
+    // INFO: Chat Notification Queue 의 Listener 입니다.
+    @RabbitListener(queues = "chulgunhazabackend_notification_queue")
+    public void receiveChatNotification(@Payload ChatNotificationDto chatNotificationDto) {
+        chatAlarmService.sendSseEvent(chatNotificationDto);
+        log.info("send Chat Alarm to : " + chatNotificationDto.employeeNo);
+    }
+
+}

--- a/src/main/java/com/example/chulgunhazabackend/security/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/example/chulgunhazabackend/security/handler/LoginSuccessHandler.java
@@ -51,7 +51,7 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
         // JSON 응답 생성
         String jsonStr = gson.toJson(responseData);
 
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setStatus(HttpServletResponse.SC_ACCEPTED);
         response.setContentType("application/json; charset=UTF-8");
 
         PrintWriter printWriter = response.getWriter();

--- a/src/main/java/com/example/chulgunhazabackend/service/ChatAlarmService.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/ChatAlarmService.java
@@ -1,0 +1,15 @@
+package com.example.chulgunhazabackend.service;
+
+import com.example.chulgunhazabackend.dto.chat.ChatNotificationDto;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+
+@Service
+public interface ChatAlarmService {
+
+    SseEmitter subscribe(Long employeeNo) throws IOException;
+
+    void sendSseEvent(ChatNotificationDto chatNotificationDto);
+}

--- a/src/main/java/com/example/chulgunhazabackend/service/ChatRabbitMQMessageService.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/ChatRabbitMQMessageService.java
@@ -1,0 +1,8 @@
+package com.example.chulgunhazabackend.service;
+
+import com.example.chulgunhazabackend.dto.chat.ChatNotificationDto;
+
+public interface ChatRabbitMQMessageService {
+
+    void sendNotification(ChatNotificationDto chatNotificationDto);
+}

--- a/src/main/java/com/example/chulgunhazabackend/service/impl/ChatAlarmServiceImpl.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/impl/ChatAlarmServiceImpl.java
@@ -1,0 +1,48 @@
+package com.example.chulgunhazabackend.service.impl;
+
+import com.example.chulgunhazabackend.dto.chat.ChatNotificationDto;
+import com.example.chulgunhazabackend.service.ChatAlarmService;
+import com.example.chulgunhazabackend.service.sse.SseEmitterManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+
+
+//HACK : 추 후 유실가능성이 있는 Sse Alarm 에 대해 처리가 필요합니다.
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatAlarmServiceImpl implements ChatAlarmService {
+
+    private final SseEmitterManager sseEmitterManager;
+
+    //INFO: Chat Sse 를 구독하는 로직입니다. 세부 로직 -> SseEmitterManager
+    @Override
+    public SseEmitter subscribe(Long employeeNo) throws IOException {
+        return sseEmitterManager.chatRegisterEmitter(employeeNo);
+    }
+
+    //INFO : 구독 중이라면 전송하는 로직입니다.
+    @Async
+    @Override
+    public void sendSseEvent(ChatNotificationDto chatNotificationDto) {
+        SseEmitter emitter = sseEmitterManager.getChatEmitter(chatNotificationDto.getEmployeeNo());
+        if (emitter != null){
+            try{
+                // HACK: 신규 구독 시 쌓여 있던 알람을 보내주는 로직을 추가합니다.
+                emitter.send(SseEmitter.event().data(chatNotificationDto));
+                log.info("send from ChatAlarmService Send sendSseEvent Method");
+            } catch (IOException e) {
+                log.info("Occur error from ChatAlarmService Send sendSseEvent Method");
+                sseEmitterManager.removeChatEmitter(chatNotificationDto.getEmployeeNo());
+            }
+        }else {
+            //HACK: 구독중이 아니라면 DB에 알람을 저장을 저장하는 로직을 추가합니다.
+            log.info("emitter is null");
+        }
+    }
+}

--- a/src/main/java/com/example/chulgunhazabackend/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/impl/ChatMessageServiceImpl.java
@@ -7,6 +7,7 @@ import com.example.chulgunhazabackend.domain.member.Employee;
 import com.example.chulgunhazabackend.dto.PageDto;
 import com.example.chulgunhazabackend.dto.chat.ChatMessageCreateRequestDto;
 import com.example.chulgunhazabackend.dto.chat.ChatMessageListResponseDto;
+import com.example.chulgunhazabackend.dto.chat.ChatNotificationDto;
 import com.example.chulgunhazabackend.exception.chatException.ChatException;
 import com.example.chulgunhazabackend.exception.chatException.ChatExceptionType;
 import com.example.chulgunhazabackend.exception.employeeException.EmployeeException;
@@ -16,14 +17,13 @@ import com.example.chulgunhazabackend.repository.ChatRoomRepository;
 import com.example.chulgunhazabackend.repository.EmployeeChatRoomRepository;
 import com.example.chulgunhazabackend.repository.EmployeeRepository;
 import com.example.chulgunhazabackend.service.ChatMessageService;
+import com.example.chulgunhazabackend.service.ChatRabbitMQMessageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.awt.*;
-import java.util.Optional;
 
 @Service
 @Transactional
@@ -34,17 +34,24 @@ public class ChatMessageServiceImpl implements ChatMessageService {
     private final ChatRoomRepository chatRoomRepository;
     private final EmployeeRepository employeeRepository;
     private final EmployeeChatRoomRepository employeeChatRoomRepository;
+    private final ChatRabbitMQMessageService chatRabbitMQMessageService;
+
     @Override
     public Long saveChatMessage(ChatMessageCreateRequestDto chatMessageCreateRequestDto) {
 
-        // 전송하려는 채팅방 존재 유무
+        // INFO: 채팅방 존재 유무 확인
         ChatRoom chatRoom = chatRoomRepository.findById(chatMessageCreateRequestDto.getRoomId()).orElseThrow(() -> new ChatException(ChatExceptionType.NOT_FOUND_CHAT_ROOM));
 
-        // 전송하려는 사원의 존재 유무
+        // INFO: 전송하는 사원의 유무 확인
+        // HACK : employeeNO 로 찾아오는 로직으로 변경 예정
         Employee employee = employeeRepository.findEmployeeById(chatMessageCreateRequestDto.getSenderId()).orElseThrow(() -> new EmployeeException(EmployeeExceptionType.NOT_EXIST_USER));
 
-        // 채팅방 인원이 아닌데 전송하는 경우
+        // INFO: 채팅방 인원이 아닌데 전송하는 경우 예외 처리
+        // HACK: employeeNO 로 찾아오는 로직으로 변경 예정
         EmployeeChatRoom employeeChatRoom = employeeChatRoomRepository.findByEmployeeIdAndChatRoomId(employee.getId(), chatRoom.getId()).orElseThrow(() -> new ChatException(ChatExceptionType.NOT_FOUND_CHAT_USER));
+
+        // HACK: 오프라인 유저, 온라인 유저 구분 로직 추가 시 로직 변경 예정
+        chatRabbitMQMessageService.sendNotification(new ChatNotificationDto(employee.getEmployeeNo(), employee.getName(), employee.getDepartment(), employee.getPosition(), employee.getEmployeeNo() + " 님 에게서 메시지가 도착했습니다."));
 
         return chatMessageRepository.save(chatMessageCreateRequestDto.toEntity(chatRoom, employee)).getId();
     }

--- a/src/main/java/com/example/chulgunhazabackend/service/impl/ChatRabbitMQMessageServiceImpl.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/impl/ChatRabbitMQMessageServiceImpl.java
@@ -1,0 +1,24 @@
+package com.example.chulgunhazabackend.service.impl;
+
+import com.example.chulgunhazabackend.dto.chat.ChatNotificationDto;
+import com.example.chulgunhazabackend.service.ChatRabbitMQMessageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatRabbitMQMessageServiceImpl implements ChatRabbitMQMessageService {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    //INFO : 채팅 알람 발생 시 RMQ 로 메시지 전송
+    public void sendNotification(ChatNotificationDto chatNotificationDto){
+        String routingKey = "chat_notification_queue_key";
+        rabbitTemplate.convertAndSend("chulgunhazabackend_chat", routingKey, chatNotificationDto);
+        log.info("Sending notification to RabbitMQ");
+    }
+
+}

--- a/src/main/java/com/example/chulgunhazabackend/service/sse/SseEmitterManager.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/sse/SseEmitterManager.java
@@ -1,0 +1,71 @@
+package com.example.chulgunhazabackend.service.sse;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class SseEmitterManager {
+
+    // HACK : 추후 Singleton 적용 후 Config 로 분리 Manager 와 Config 를 분리해서 사용.
+    private final Map<EmitterType, Map<Long, SseEmitter>> emitters = new ConcurrentHashMap<>();
+
+    // INFO: Emitter type 은 Main 과 chat 2가지 입니다.
+    public enum EmitterType{
+        CHAT, MAIN;
+    }
+
+    @PostConstruct
+    public void init() {
+
+        emitters.put(EmitterType.CHAT, new ConcurrentHashMap<>());
+        emitters.put(EmitterType.MAIN, new ConcurrentHashMap<>());
+
+    }
+
+    // INFO: chatEmitter 를 등록하고 반환하는 메서드 입니다.
+    public SseEmitter chatRegisterEmitter(Long employeeNo) {
+
+        SseEmitter emitter = new SseEmitter(10000000L);
+        emitters.get(EmitterType.CHAT).put(employeeNo, emitter);
+        emitter.onCompletion(() -> emitters.get(EmitterType.CHAT).remove(employeeNo));
+        emitter.onTimeout(() -> emitters.get(EmitterType.CHAT).remove(employeeNo));
+
+        sendEmitterData(EmitterType.CHAT, emitter, employeeNo, "ChatSseConnect", "Success Chat SSE");
+        return emitter;
+
+    }
+    // INFO: chatEmitter 를 가져오는 로직
+    public SseEmitter getChatEmitter(Long employeeNo) {
+        return emitters.get(EmitterType.CHAT).get(employeeNo);
+    }
+
+    // INFO chatEmitter 를 제거하는 로직
+    public void removeChatEmitter(Long employeeNo) {
+        emitters.get(EmitterType.CHAT).remove(employeeNo);
+    }
+
+    // INFO: 모든 Emitter 를 제거하는 로직 -> logout 시에 사용
+    public void clearEmitters() {
+        emitters.forEach((type, emitterMap) -> emitterMap.clear());
+    }
+
+    // INFO: client 기본 유지를 데이터를 보내는 메서드
+    public void sendEmitterData(EmitterType type, SseEmitter emitter, Long employeeNo, String name, String data) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(Long.toString(employeeNo))
+                    .name(name)
+                    .data(data));
+
+        } catch (IOException e) {
+            emitters.get(type).remove(employeeNo);
+            emitter.complete();
+        }
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,7 +30,12 @@ spring:
   session:
     store-type: redis
 
-
+  rabbitmq:
+    host: ${SPRING_RABBITMQ_HOST}
+    port: 5672
+    username: ${RMQ_USERNAME}
+    password: ${RMQ_PASSWORD}
+    virtual-host: /
   # 파일 업로드 설정
   servlet:
     multipart:


### PR DESCRIPTION
## #️⃣연관된 이슈

#33 

## 📝작업 내용

1. 비동기 설정을 추가 했습니다. -> AsyncConfig
![image](https://github.com/user-attachments/assets/e3356678-28b7-47c5-b0fd-d82109d5e03d)


2. RMQ 설정을 완료 했습니다. Main Queue, Chat Queue , 라우팅 키를 기준으로 Queue 에 전송하기 위헤 DirectExchange 를 사용했습니다. RMQ 는 내부적으로 SimpleMessageListenerContainer 를 이용해 메시지를 비동기 처리 합니다. 
![image](https://github.com/user-attachments/assets/2466af55-82e4-4499-9864-d7d49435be3b)


3. RMQ 메시지 소비를 위한 Listener 를 추가했습니다. 
![image](https://github.com/user-attachments/assets/225abf2f-1abe-426b-918e-0f8e4b6b9903)

4. SseEmitterManager 를 통해 Sse 관리 로직을 분리했습니다. 

## 💬리뷰 요구사항(선택)
수정 필요 사항을 주석으로 처리했습니다!. 수정 필요한 부분이 있으면 말씀해주세요~!

