### PR TITLE
[FEAT] 사원 출근 등록 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,10 @@ dependencies {
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")
 
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
+
+    // spring retry
+    implementation 'org.springframework.retry:spring-retry'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/chulgunhazabackend/ChulgunhazaBackendApplication.java
+++ b/src/main/java/com/example/chulgunhazabackend/ChulgunhazaBackendApplication.java
@@ -3,6 +3,7 @@ package com.example.chulgunhazabackend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -10,6 +11,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableJpaAuditing
 @EnableScheduling
 @EnableAsync
+@EnableRetry
 public class ChulgunhazaBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/chulgunhazabackend/config/RabbitMQConfig.java
+++ b/src/main/java/com/example/chulgunhazabackend/config/RabbitMQConfig.java
@@ -1,10 +1,9 @@
 package com.example.chulgunhazabackend.config;
 
-import org.springframework.amqp.core.Binding;
-import org.springframework.amqp.core.BindingBuilder;
-import org.springframework.amqp.core.DirectExchange;
-import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.*;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.config.RetryInterceptorBuilder;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
@@ -17,24 +16,39 @@ import org.springframework.context.annotation.Configuration;
 @EnableRabbit
 public class RabbitMQConfig {
 
-    // INFO: Domain Queue
-    private static final String CHAT_QUEUE_NAME = "chulgunhazabackend_chat_queue";
-    private static final String MAIN_QUEUE_NAME = "chulgunhazabackend_record_queue";
+    // INFO: Domain Queue - CHAT
+    public static final String CHAT_QUEUE_NAME = "chulgunhazabackend_chat_queue";
 
-    // INFO: Notification Queue
-    private static final String CHAT_NOTIFICATION_QUEUE_NAME = "chulgunhazabackend_notification_queue";
-    private static final String MAIN_NOTIFICATION_QUEUE_NAME = "chulgunhazabackend_record_notification_queue";
+    // INFO: Domain Queue - MAIN
+    public static final String ATTENDANCE_QUEUE_NAME = "chulgunhazabackend_attendance_queue";
+    public static final String LEAVE_WORK_QUEUE_NAME = "chulgunhazabackend_leave_work_queue";
+
+    // INFO: Notification Queue - CHAT
+    public static final String CHAT_NOTIFICATION_QUEUE_NAME = "chulgunhazabackend_notification_queue";
+
+    // INFO: Notification Queue - MAIN
+    public static final String MAIN_NOTIFICATION_QUEUE_NAME = "chulgunhazabackend_record_notification_queue";
 
 
-    // INFO: Exchange
-    private static final String CHAT_EXCHANGE_NAME = "chulgunhazabackend_chat";
-    private static final String MAIN_EXCHANGE_NAME = "chulgunhazabackend_main";
+    // INFO: Exchange - Chat
+    public static final String CHAT_EXCHANGE_NAME = "chulgunhazabackend_chat";
 
-    // INFO: Routing Key
-    private static final String CHAT_ROUTING_KEY = "chat_queue_key";
-    private static final String CHAT_NOTIFICATION_ROUTING_KEY = "chat_notification_queue_key";
-    private static final String MAIN_ROUTING_KEY = "main_queue_key";
-    private static final String MAIN_NOTIFICATION_ROUTING_KEY = "main_notification_queue_key";
+    // INFO: Exchange - Main
+    public static final String MAIN_EXCHANGE_NAME = "chulgunhazabackend_main";
+
+    // INFO: Routing Key - Chat
+    public static final String CHAT_ROUTING_KEY = "chat_queue_key";
+    public static final String CHAT_NOTIFICATION_ROUTING_KEY = "chat_notification_queue_key";
+
+    // INFO: Routing Key - Main
+    public static final String ATTENDANCE_ROUTING_KEY = "attendance_queue_key";
+    public static final String LEAVE_WORK_ROUTING_KEY = "leave_work_queue_key";
+    public static final String MAIN_NOTIFICATION_ROUTING_KEY = "main_notification_queue_key";
+
+    // Dead - Letter
+    public static final String DLX = "deadLetterExchange";
+    public static final String A_DLQ = "attendanceDeadLetterQueue";
+
 
 
     @Bean
@@ -48,13 +62,26 @@ public class RabbitMQConfig {
     }
 
     @Bean
-    public Queue mainQueue() {
-        return new Queue(MAIN_QUEUE_NAME,true);
+    public Queue attendanceQueue() {
+        return QueueBuilder.durable(ATTENDANCE_QUEUE_NAME)
+                .withArgument("x-dead-letter-exchange", DLX)
+                .withArgument("x-dead-letter-routing-key", A_DLQ)
+                .build();
+    }
+
+    @Bean
+    public Queue leaveWorkQueue() {
+        return new Queue(LEAVE_WORK_QUEUE_NAME,true);
     }
 
     @Bean
     public Queue mainNotificationQueue() {
         return new Queue(MAIN_NOTIFICATION_QUEUE_NAME,true);
+    }
+
+    @Bean
+    public Queue attendanceDeadLetterQueue(){
+        return QueueBuilder.durable(A_DLQ).build();
     }
 
     @Bean
@@ -68,6 +95,11 @@ public class RabbitMQConfig {
     }
 
     @Bean
+    public TopicExchange deadLetterExchange(){
+        return new TopicExchange(DLX);
+    }
+
+    @Bean
     public Binding chatBinding() {
         return BindingBuilder.bind(chatQueue()).to(chatExchange()).with(CHAT_ROUTING_KEY);
     }
@@ -78,8 +110,12 @@ public class RabbitMQConfig {
     }
 
     @Bean
-    public Binding mainBinding() {
-        return BindingBuilder.bind(mainQueue()).to(mainExchange()).with(MAIN_ROUTING_KEY);
+    public Binding mainAttendanceBinding() {
+        return BindingBuilder.bind(attendanceQueue()).to(mainExchange()).with(ATTENDANCE_ROUTING_KEY);
+    }
+    @Bean
+    public Binding mainLeaveWorkBinding() {
+        return BindingBuilder.bind(leaveWorkQueue()).to(mainExchange()).with(LEAVE_WORK_ROUTING_KEY);
     }
 
     @Bean
@@ -88,11 +124,32 @@ public class RabbitMQConfig {
     }
 
     @Bean
+    public Binding attendanceDeadLetterBinding() {
+        return BindingBuilder.bind(attendanceDeadLetterQueue()).to(deadLetterExchange()).with(A_DLQ);
+    }
+
+    // 메시지 송신 빈 등록
+    @Bean
     public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
-        rabbitTemplate.setMessageConverter(new Jackson2JsonMessageConverter());
+        rabbitTemplate.setMessageConverter(jsonMessageConverter());
         return rabbitTemplate;
     }
+
+    // 메세지 수신 빈 등록
+    @Bean
+    public SimpleRabbitListenerContainerFactory simpleRabbitListenerContainerFactory(
+            ConnectionFactory connectionFactory){
+        SimpleRabbitListenerContainerFactory listenerContainerFactory
+                = new SimpleRabbitListenerContainerFactory();
+        listenerContainerFactory.setConnectionFactory(connectionFactory);
+        listenerContainerFactory.setDefaultRequeueRejected(false);
+        listenerContainerFactory.setAcknowledgeMode(AcknowledgeMode.MANUAL);
+        listenerContainerFactory.setMessageConverter(jsonMessageConverter());
+
+        return listenerContainerFactory;
+    }
+
 
     // JSON 변환기
     @Bean

--- a/src/main/java/com/example/chulgunhazabackend/controller/AttendanceController.java
+++ b/src/main/java/com/example/chulgunhazabackend/controller/AttendanceController.java
@@ -1,0 +1,27 @@
+package com.example.chulgunhazabackend.controller;
+
+import com.example.chulgunhazabackend.dto.attendance.AttendanceCreateRequestDto;
+import com.example.chulgunhazabackend.service.AttendanceRabbitMQService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/attendance")
+@RequiredArgsConstructor
+public class AttendanceController {
+
+    private final AttendanceRabbitMQService attendanceRabbitMQService;
+
+    @PostMapping("/register")
+    public ResponseEntity<?> registerAttendance(@Valid @RequestBody AttendanceCreateRequestDto attendanceCreateRequestDto){
+        attendanceRabbitMQService.sendAttendanceDto(attendanceCreateRequestDto);
+        return ResponseEntity.ok().body("성공");
+    }
+
+
+}

--- a/src/main/java/com/example/chulgunhazabackend/domain/attendance/AttendanceRecord.java
+++ b/src/main/java/com/example/chulgunhazabackend/domain/attendance/AttendanceRecord.java
@@ -33,4 +33,10 @@ public class AttendanceRecord extends BaseEntity {
     private AttendanceType attendanceType;
 
 
+    @Builder
+    public AttendanceRecord(Employee employee, LocalDateTime checkInTime, AttendanceType attendanceType) {
+        this.employee = employee;
+        this.checkInTime = checkInTime;
+        this.attendanceType = attendanceType;
+    }
 }

--- a/src/main/java/com/example/chulgunhazabackend/dto/attendance/AttendanceCreateRequestDto.java
+++ b/src/main/java/com/example/chulgunhazabackend/dto/attendance/AttendanceCreateRequestDto.java
@@ -1,0 +1,53 @@
+package com.example.chulgunhazabackend.dto.attendance;
+
+import com.example.chulgunhazabackend.domain.attendance.AttendanceRecord;
+import com.example.chulgunhazabackend.domain.attendance.AttendanceType;
+import com.example.chulgunhazabackend.domain.member.Employee;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+
+@Getter
+@AllArgsConstructor
+@ToString
+public class AttendanceCreateRequestDto implements Serializable {
+
+
+    @NotNull(message = "출근자의 사원 번호가 누락되었습니다.")
+    private Long employeeNo; // 사원 번호
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @NotNull(message = "출근 시간이 누락되었습니다.")
+    private LocalDateTime checkInTime;
+
+    @Setter
+    private String mqFailMessage;
+
+
+    public AttendanceRecord toEntity(Employee employee){
+        return AttendanceRecord.builder()
+                .employee(employee)
+                .checkInTime(checkInTime)
+                .attendanceType(setAttendanceType(checkInTime))
+                .build();
+    }
+
+    private AttendanceType setAttendanceType(LocalDateTime checkInTime){
+
+        // 기준 시간 (09 : 00)
+        LocalTime standardTime = LocalTime.of(9, 0);
+
+        return checkInTime.toLocalTime().isAfter(standardTime)
+                ? AttendanceType.LATE : AttendanceType.NORMAL;
+        // 결근 처리 추가 예정 
+    }
+
+
+
+}

--- a/src/main/java/com/example/chulgunhazabackend/event/attendance/event/AttendanceCreateEvent.java
+++ b/src/main/java/com/example/chulgunhazabackend/event/attendance/event/AttendanceCreateEvent.java
@@ -1,0 +1,17 @@
+package com.example.chulgunhazabackend.event.attendance.event;
+
+import com.example.chulgunhazabackend.event.common.Event;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class AttendanceCreateEvent extends Event {
+
+    private final String message;
+
+    public AttendanceCreateEvent(Long employeeNumber) {
+        super(employeeNumber);
+        this.message = "출근등록이 완료되었습니다.";
+    }
+}

--- a/src/main/java/com/example/chulgunhazabackend/event/attendance/handler/AttendanceCreateEventHandler.java
+++ b/src/main/java/com/example/chulgunhazabackend/event/attendance/handler/AttendanceCreateEventHandler.java
@@ -1,0 +1,27 @@
+package com.example.chulgunhazabackend.event.attendance.handler;
+
+import com.example.chulgunhazabackend.event.attendance.event.AttendanceCreateEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+public class AttendanceCreateEventHandler {
+
+    @Async
+    @TransactionalEventListener(
+            classes = AttendanceCreateEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT
+    )
+    public void handleAttendanceCreateEventAfterCommit(AttendanceCreateEvent attendanceCreateEvent){
+        System.out.println("이벤트 등록 : " + attendanceCreateEvent);
+    }
+
+
+
+
+
+}

--- a/src/main/java/com/example/chulgunhazabackend/listener/AttendanceListener.java
+++ b/src/main/java/com/example/chulgunhazabackend/listener/AttendanceListener.java
@@ -1,0 +1,58 @@
+package com.example.chulgunhazabackend.listener;
+
+import com.example.chulgunhazabackend.config.RabbitMQConfig;
+import com.example.chulgunhazabackend.dto.attendance.AttendanceCreateRequestDto;
+import com.example.chulgunhazabackend.dto.chat.ChatNotificationDto;
+import com.example.chulgunhazabackend.exception.employeeException.EmployeeException;
+import com.example.chulgunhazabackend.exception.employeeException.EmployeeExceptionType;
+import com.example.chulgunhazabackend.service.impl.AttendanceServiceImpl;
+import com.rabbitmq.client.Channel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AttendanceListener {
+
+    private final AttendanceServiceImpl attendanceService; // 다형성 수정
+    private final RabbitTemplate rabbitTemplate;
+
+
+    @RabbitListener(queues = RabbitMQConfig.ATTENDANCE_QUEUE_NAME, containerFactory = "simpleRabbitListenerContainerFactory")
+    public void attendanceConsume(@Payload AttendanceCreateRequestDto attendanceCreateRequestDto,
+                                  Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag) throws IOException {
+        try {
+            attendanceService.registerAttendance(attendanceCreateRequestDto);
+            channel.basicAck(tag, false); // 성공
+            System.out.println("디큐 완료");
+        }catch (EmployeeException e){
+
+            System.out.println("확인 : " + e.getMessage());// 메세지를 보내야 함 (출근 등록이 실패하였습니다 : 이유)
+            channel.basicNack(tag, false, false); // 큐에 있는 메세지 삭제
+
+        } catch (Exception e) {
+            // DLQ 이동
+            attendanceCreateRequestDto.setMqFailMessage(e.getMessage());
+            rabbitTemplate.convertAndSend(RabbitMQConfig.DLX, RabbitMQConfig.A_DLQ, attendanceCreateRequestDto);
+            System.out.println("DLQ 이동 : " + e.getMessage());
+        }
+
+    }
+
+}
+
+

--- a/src/main/java/com/example/chulgunhazabackend/listener/deadLetterListener/AttendanceDeadLetterListener.java
+++ b/src/main/java/com/example/chulgunhazabackend/listener/deadLetterListener/AttendanceDeadLetterListener.java
@@ -1,0 +1,38 @@
+package com.example.chulgunhazabackend.listener.deadLetterListener;
+
+import com.example.chulgunhazabackend.config.RabbitMQConfig;
+import com.example.chulgunhazabackend.dto.attendance.AttendanceCreateRequestDto;
+import com.example.chulgunhazabackend.service.impl.AttendanceServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AttendanceDeadLetterListener {
+
+    private final AttendanceServiceImpl attendanceService;
+    @RabbitListener(queues = RabbitMQConfig.A_DLQ, containerFactory = "simpleRabbitListenerContainerFactory")
+    @Retryable(
+            retryFor = {Exception.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 1000),
+            recover = "attendanceDLQConsumeRecover"
+    )
+    public void attendanceDlqConsume(@Payload AttendanceCreateRequestDto attendanceCreateRequestDto) throws Exception {
+        System.out.println(attendanceCreateRequestDto);
+        attendanceService.registerAttendance(attendanceCreateRequestDto);
+        System.out.println("출근 - DLQ 디큐 완료");
+    }
+
+    @Recover
+    public void attendanceDLQConsumeRecover(Exception e, AttendanceCreateRequestDto attendanceCreateRequestDto){
+        System.out.println("DLQ 리커버 메시지 : " + e.getMessage());
+        // 어드민 알람으로 발행
+    }
+
+}

--- a/src/main/java/com/example/chulgunhazabackend/repository/AttendanceRecordRepository.java
+++ b/src/main/java/com/example/chulgunhazabackend/repository/AttendanceRecordRepository.java
@@ -1,0 +1,8 @@
+package com.example.chulgunhazabackend.repository;
+
+import com.example.chulgunhazabackend.domain.attendance.AttendanceRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AttendanceRecordRepository extends JpaRepository<AttendanceRecord, Long> {
+
+}

--- a/src/main/java/com/example/chulgunhazabackend/repository/EmployeeRepository.java
+++ b/src/main/java/com/example/chulgunhazabackend/repository/EmployeeRepository.java
@@ -21,6 +21,8 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
     Optional<Employee> findEmployeeById(Long id);
 
+    Optional<Employee> findEmployeeByEmployeeNo(Long employeeNo);
+
     @Query("SELECT e FROM Employee e " +
             "WHERE e.delFlag = false " +
             "ORDER BY e.department ASC, e.position, e.name")

--- a/src/main/java/com/example/chulgunhazabackend/security/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/example/chulgunhazabackend/security/handler/LoginSuccessHandler.java
@@ -45,6 +45,8 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
         // 응답 데이터 생성
         Map<String, Object> responseData = new HashMap<>();
         responseData.put("message", "로그인 성공");
+        responseData.put("depart", claims.get("department"));
+        responseData.put("name", claims.get("name"));
         responseData.put("employeeNo", claims.get("employeeNo"));
         responseData.put("employeeRoles", claims.get("roles"));
 

--- a/src/main/java/com/example/chulgunhazabackend/service/AttendanceAlarmService.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/AttendanceAlarmService.java
@@ -1,0 +1,4 @@
+package com.example.chulgunhazabackend.service;
+
+public interface AttendanceAlarmService {
+}

--- a/src/main/java/com/example/chulgunhazabackend/service/AttendanceRabbitMQService.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/AttendanceRabbitMQService.java
@@ -1,0 +1,7 @@
+package com.example.chulgunhazabackend.service;
+
+import com.example.chulgunhazabackend.dto.attendance.AttendanceCreateRequestDto;
+
+public interface AttendanceRabbitMQService {
+    void sendAttendanceDto (AttendanceCreateRequestDto attendanceCreateRequestDto);
+}

--- a/src/main/java/com/example/chulgunhazabackend/service/impl/AttendanceAlarmServiceImpl.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/impl/AttendanceAlarmServiceImpl.java
@@ -1,0 +1,22 @@
+package com.example.chulgunhazabackend.service.impl;
+
+import com.example.chulgunhazabackend.service.sse.SseEmitterManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AttendanceAlarmServiceImpl {
+
+    private final SseEmitterManager sseEmitterManager;
+    public SseEmitter subscribe(Long employeeNo) throws IOException {
+        return sseEmitterManager.mainRegisterEmitter(employeeNo);
+    }
+
+
+}

--- a/src/main/java/com/example/chulgunhazabackend/service/impl/AttendanceRabbitMQServiceImpl.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/impl/AttendanceRabbitMQServiceImpl.java
@@ -1,0 +1,24 @@
+package com.example.chulgunhazabackend.service.impl;
+
+import com.example.chulgunhazabackend.config.RabbitMQConfig;
+import com.example.chulgunhazabackend.dto.attendance.AttendanceCreateRequestDto;
+import com.example.chulgunhazabackend.service.AttendanceRabbitMQService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AttendanceRabbitMQServiceImpl implements AttendanceRabbitMQService {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public void sendAttendanceDto(AttendanceCreateRequestDto attendanceCreateRequestDto){
+        rabbitTemplate.convertAndSend(RabbitMQConfig.MAIN_EXCHANGE_NAME,
+                RabbitMQConfig.ATTENDANCE_ROUTING_KEY, attendanceCreateRequestDto);
+        log.info("메세지 큐 등록:  ${}", attendanceCreateRequestDto);
+    }
+
+}

--- a/src/main/java/com/example/chulgunhazabackend/service/impl/AttendanceServiceImpl.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/impl/AttendanceServiceImpl.java
@@ -1,0 +1,35 @@
+package com.example.chulgunhazabackend.service.impl;
+
+import com.example.chulgunhazabackend.domain.member.Employee;
+import com.example.chulgunhazabackend.dto.attendance.AttendanceCreateRequestDto;
+import com.example.chulgunhazabackend.event.attendance.event.AttendanceCreateEvent;
+import com.example.chulgunhazabackend.event.common.Events;
+import com.example.chulgunhazabackend.exception.employeeException.EmployeeException;
+import com.example.chulgunhazabackend.exception.employeeException.EmployeeExceptionType;
+import com.example.chulgunhazabackend.repository.AttendanceRecordRepository;
+import com.example.chulgunhazabackend.repository.EmployeeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AttendanceServiceImpl {
+
+    private final EmployeeRepository employeeRepository;
+    private final AttendanceRecordRepository attendanceRecordRepository;
+
+    public void registerAttendance(AttendanceCreateRequestDto attendanceCreateRequestDto) {
+        //TODO : 이벤트 발행 후 SSE로 이벤트 뿌리기
+
+        Events.raise(new AttendanceCreateEvent(attendanceCreateRequestDto.getEmployeeNo()));
+
+        Employee employee = employeeRepository
+                .findEmployeeByEmployeeNo(attendanceCreateRequestDto.getEmployeeNo())
+                .orElseThrow(() -> new EmployeeException(EmployeeExceptionType.NOT_EXIST_USER));
+        attendanceRecordRepository.save(attendanceCreateRequestDto.toEntity(employee));
+    }
+
+
+}

--- a/src/main/java/com/example/chulgunhazabackend/service/impl/EmployeeServiceImpl.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/impl/EmployeeServiceImpl.java
@@ -53,9 +53,6 @@ public class EmployeeServiceImpl implements EmployeeService {
         Employee employee = employeeCreateRequestDto.toEntity(employeeImage, new Annual());
         employee.setInitialPassword(passwordEncoder); // 초기 비밀번호 지정
         Employee saved = employeeRepository.save(employee);
-        System.out.println("생성됨");
-        System.out.println(saved.getId());
-
         return saved.getId();
     }
 

--- a/src/main/java/com/example/chulgunhazabackend/service/sse/SseEmitterManager.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/sse/SseEmitterManager.java
@@ -39,6 +39,19 @@ public class SseEmitterManager {
         return emitter;
 
     }
+
+    // INFO: mainEmitter 를 등록하고 반환하는 메서드 입니다.
+   public SseEmitter mainRegisterEmitter(Long employeeNo){
+       SseEmitter emitter = new SseEmitter(10000000L);
+       emitters.get(EmitterType.MAIN).put(employeeNo, emitter);
+       emitter.onCompletion(() -> emitters.get(EmitterType.MAIN).remove(employeeNo));
+       emitter.onTimeout(() -> emitters.get(EmitterType.MAIN).remove(employeeNo));
+       sendEmitterData(EmitterType.MAIN, emitter, employeeNo, "MainSseConnect", "Success Main SSE");
+       return emitter;
+   }
+
+
+
     // INFO: chatEmitter 를 가져오는 로직
     public SseEmitter getChatEmitter(Long employeeNo) {
         return emitters.get(EmitterType.CHAT).get(employeeNo);
@@ -47,6 +60,15 @@ public class SseEmitterManager {
     // INFO chatEmitter 를 제거하는 로직
     public void removeChatEmitter(Long employeeNo) {
         emitters.get(EmitterType.CHAT).remove(employeeNo);
+    }
+
+    // INFO: mainEmitter 를 가져오는 로직
+    public SseEmitter getMainEmitter(Long employeeNo){
+        return emitters.get(EmitterType.MAIN).get(employeeNo);
+    }
+
+    public void removeMainEmitter(Long employeeNo) {
+        emitters.get(EmitterType.MAIN).remove(employeeNo);
     }
 
     // INFO: 모든 Emitter 를 제거하는 로직 -> logout 시에 사용

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,12 +30,6 @@ spring:
   session:
     store-type: redis
 
-  rabbitmq:
-    host: ${SPRING_RABBITMQ_HOST}
-    port: 5672
-    username: ${RMQ_USERNAME}
-    password: ${RMQ_PASSWORD}
-    virtual-host: /
   # 파일 업로드 설정
   servlet:
     multipart:


### PR DESCRIPTION
## #️⃣연관된 이슈
#39 

## 📝작업 내용

### 출근 등록을 하는 경우에 RMQueue를 사용하여 출근 등록을 진행합니다. 

![image](https://github.com/user-attachments/assets/e6e30825-e4e7-4126-8273-84d665ea1061)
* 출근 등록을 진행하는 경우 서버 부하 방지를 위해 출근 큐를 타게 합니다.

![image](https://github.com/user-attachments/assets/26726eb5-09a7-4e88-867c-61ea41507e83)
* 큐에 있는 출근 객체를 꺼내는 경우, 커스텀 예외가 발생하는 경우 큐에 있는 메세지를 삭제한 다음 어드민 메세지로 발행할 예정입니다.(삭제하는 이유는 잘못된 메세지가 큐에 남아있으면 안 되기 때문입니다.)
* 그 외 다른 예외가 터지는 경우 해당 객체는 A_DLQ(Attendance_DeadLetterQueue)를 타게 됩니다.

![image](https://github.com/user-attachments/assets/9d89c825-392b-42e4-a499-5867a7f32d91)
* DLQ 이동 후 해당 출근 객체는 Spring Retry를 활용하여 세 번 출근 등록을 재시도합니다. 
* 3번의 재시도를 전부 실패하는 경우 어드민에게 메세지를 발행할 예정입니다. 

![image](https://github.com/user-attachments/assets/c19009cb-5783-4c7f-b2ed-2909e6bf3e5c)
* 출근 등록이 완료되면(트랜잭션 커밋 시점) 이벤트를 발행하게 하여 당사자에게 출근 등록이 완료되었다고 메세지를 발행합니다. 
  

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
* 잘못된 부분은 바로 수정하겠습니다.
