### PR TITLE
[FEAT] Chat, Notification, Websocket, sse 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     // rabbitMQ
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
 
+    // websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
     // serialize
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 

--- a/src/main/java/com/example/chulgunhazabackend/config/WebSocketConfig.java
+++ b/src/main/java/com/example/chulgunhazabackend/config/WebSocketConfig.java
@@ -15,6 +15,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
 
     private final WebSocketHandler webSocketHandler;
 
+    // INFO : WebSocket 연결을 위한 설정입니다. 또한 웹 소켓 세션을 받을 때 시큐리티 컨텍스트의 정보 함께 받는 Interceptor 를 사용하고 있습니다.
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry webSocketHandlerRegistry) {
         webSocketHandlerRegistry.addHandler(webSocketHandler, "/websocket")

--- a/src/main/java/com/example/chulgunhazabackend/config/WebSocketConfig.java
+++ b/src/main/java/com/example/chulgunhazabackend/config/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package com.example.chulgunhazabackend.config;
+
+import com.example.chulgunhazabackend.security.interceptor.SecurityContextInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final WebSocketHandler webSocketHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry webSocketHandlerRegistry) {
+        webSocketHandlerRegistry.addHandler(webSocketHandler, "/websocket")
+                .addInterceptors(new SecurityContextInterceptor())
+                .setAllowedOrigins("*");
+    }
+}

--- a/src/main/java/com/example/chulgunhazabackend/controller/ChatController.java
+++ b/src/main/java/com/example/chulgunhazabackend/controller/ChatController.java
@@ -1,18 +1,19 @@
 package com.example.chulgunhazabackend.controller;
 
+import com.example.chulgunhazabackend.dto.Employee.EmployeeCredentialDto;
 import com.example.chulgunhazabackend.dto.PageDto;
 import com.example.chulgunhazabackend.dto.chat.ChatMessageCreateRequestDto;
 import com.example.chulgunhazabackend.dto.chat.ChatMessageListResponseDto;
 import com.example.chulgunhazabackend.dto.chat.ChatRoomCreateRequestDto;
 import com.example.chulgunhazabackend.dto.chat.ChatRoomListResponseDto;
 import com.example.chulgunhazabackend.service.ChatMessageService;
+import com.example.chulgunhazabackend.service.ChatRabbitMQMessageService;
 import com.example.chulgunhazabackend.service.ChatRoomService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -23,25 +24,34 @@ public class ChatController {
 
     private final ChatRoomService chatRoomService;
     private final ChatMessageService chatMessageService;
+    private final ChatRabbitMQMessageService chatRabbitMQMessageService;
 
+
+    // INFO : 채팅방을 생성하기 위한 컨트롤러입니다.
     @PostMapping("/create")
-    public ResponseEntity<Long> createRoom(@RequestBody ChatRoomCreateRequestDto chatRoomCreateRequestDto){
-        return ResponseEntity.ok().body(chatRoomService.saveChatRoom(chatRoomCreateRequestDto));
+    public ResponseEntity<Long> createRoom(@Valid @RequestBody ChatRoomCreateRequestDto chatRoomCreateRequestDto
+                                                , @AuthenticationPrincipal EmployeeCredentialDto employeeCredentialDto){
+        return ResponseEntity.ok().body(chatRoomService.saveChatRoom(chatRoomCreateRequestDto, employeeCredentialDto.getId()));
     }
 
-    @GetMapping("/find/rooms/{employeeId}")
-    public ResponseEntity<PageDto<ChatRoomListResponseDto>> findAllByEmployeeId(@PathVariable Long employeeId, Pageable pageable){
-        return ResponseEntity.ok().body(chatRoomService.getAllChatRoomsByEmployeeId(employeeId, pageable));
+    // INFO : 전체 채팅방을 가져오는 컨트롤러입니다.
+    @GetMapping("/find/rooms")
+    public ResponseEntity<PageDto<ChatRoomListResponseDto>> findAllByEmployeeId(@AuthenticationPrincipal EmployeeCredentialDto employeeCredentialDto, Pageable pageable){
+        return ResponseEntity.ok().body(chatRoomService.getAllChatRoomsByEmployeeId(employeeCredentialDto.getId(), pageable));
     }
 
+    // INFO : 메시지 전송을 위한 컨트롤러 입니다.
+    // HACK : return 값 추후 수정 필요.
     @PostMapping("/send")
-    public ResponseEntity<Long> createMessage(@Valid @RequestBody ChatMessageCreateRequestDto chatMessageCreateRequestDto){
-        return ResponseEntity.ok().body(chatMessageService.saveChatMessage(chatMessageCreateRequestDto));
+    public ResponseEntity<String> createMessage(@Valid @RequestBody ChatMessageCreateRequestDto chatMessageCreateRequestDto, @AuthenticationPrincipal EmployeeCredentialDto employeeCredentialDto){
+        return ResponseEntity.ok().body(chatRabbitMQMessageService.sendChatMessage(chatMessageCreateRequestDto, employeeCredentialDto.getId()));
     }
 
+    // INFO : 채팅내역을 가져오는 컨트롤러 입니다.
+    // HACK : 추후 배치 처리 필요.
     @GetMapping("/find/{chatRoomId}")
-    public ResponseEntity<PageDto<ChatMessageListResponseDto>> findChatMessage(@PathVariable Long chatRoomId, @PageableDefault(30) Pageable pageable){
-        return ResponseEntity.ok().body(chatMessageService.getChatMessagesByRoomId(chatRoomId, pageable));
+    public ResponseEntity<PageDto<ChatMessageListResponseDto>> findChatMessage(@AuthenticationPrincipal EmployeeCredentialDto employeeCredentialDto, @PathVariable Long chatRoomId, Pageable pageable){
+        return ResponseEntity.ok().body(chatMessageService.getChatMessagesByRoomId(chatRoomId, employeeCredentialDto.getId(), pageable));
     }
 
 }

--- a/src/main/java/com/example/chulgunhazabackend/controller/NotificationController.java
+++ b/src/main/java/com/example/chulgunhazabackend/controller/NotificationController.java
@@ -1,10 +1,12 @@
 package com.example.chulgunhazabackend.controller;
 
 
+import com.example.chulgunhazabackend.dto.Employee.EmployeeCredentialDto;
 import com.example.chulgunhazabackend.service.ChatAlarmService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,9 +22,9 @@ public class NotificationController{
 
     private final ChatAlarmService chatAlarmService;
 
-    @GetMapping(value ="/subscribe/chat/{employeeNo}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribeChat(@PathVariable Long employeeNo) throws IOException {
-        return chatAlarmService.subscribe(employeeNo);
+    @GetMapping(value ="/subscribe/chat", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribeChat(@AuthenticationPrincipal EmployeeCredentialDto employeeCredentialDto ) throws IOException {
+        return chatAlarmService.subscribe(employeeCredentialDto.getId());
     }
 
     //TODO: MAIN Controller 생성

--- a/src/main/java/com/example/chulgunhazabackend/domain/chat/ChatMessage.java
+++ b/src/main/java/com/example/chulgunhazabackend/domain/chat/ChatMessage.java
@@ -4,6 +4,9 @@ import com.example.chulgunhazabackend.domain.common.BaseEntity;
 import com.example.chulgunhazabackend.domain.member.Employee;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,4 +33,12 @@ public class ChatMessage extends BaseEntity{
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "employee_id")
     private Employee employee;
+
+    @ColumnDefault("false")
+    @Column(insertable = false)
+    private boolean isRead;
+
+    @Column(nullable = false, name = "create_time")
+    private LocalDateTime createTime;
+
 }

--- a/src/main/java/com/example/chulgunhazabackend/dto/chat/ChatMessageCreateRMQDto.java
+++ b/src/main/java/com/example/chulgunhazabackend/dto/chat/ChatMessageCreateRMQDto.java
@@ -6,6 +6,8 @@ import com.example.chulgunhazabackend.domain.member.Employee;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @AllArgsConstructor
 public class ChatMessageCreateRMQDto {
@@ -18,12 +20,14 @@ public class ChatMessageCreateRMQDto {
 
     private Long roomId;
 
+    private LocalDateTime creatTime;
 
     public ChatMessage toEntity(ChatRoom chatRoom, Employee employee){
         return ChatMessage.builder()
                 .employee(employee)
                 .chatRoom(chatRoom)
                 .message(message)
+                .createTime(creatTime)
                 .build();
     }
 }

--- a/src/main/java/com/example/chulgunhazabackend/dto/chat/ChatMessageCreateRMQDto.java
+++ b/src/main/java/com/example/chulgunhazabackend/dto/chat/ChatMessageCreateRMQDto.java
@@ -1,0 +1,29 @@
+package com.example.chulgunhazabackend.dto.chat;
+
+import com.example.chulgunhazabackend.domain.chat.ChatMessage;
+import com.example.chulgunhazabackend.domain.chat.ChatRoom;
+import com.example.chulgunhazabackend.domain.member.Employee;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatMessageCreateRMQDto {
+
+    private Long senderId;
+
+    private Long receiverId;
+
+    private String message;
+
+    private Long roomId;
+
+
+    public ChatMessage toEntity(ChatRoom chatRoom, Employee employee){
+        return ChatMessage.builder()
+                .employee(employee)
+                .chatRoom(chatRoom)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/example/chulgunhazabackend/dto/chat/ChatMessageCreateRequestDto.java
+++ b/src/main/java/com/example/chulgunhazabackend/dto/chat/ChatMessageCreateRequestDto.java
@@ -8,13 +8,16 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @Getter
-public class ChatMessageCreateRequestDto{
+public class ChatMessageCreateRequestDto {
 
-    @NotNull(message = "전송자 아이디가 누락되었습니다.")
-    private Long senderId;
+    @NotNull(message = "수신자 아이디가 누락되었습니다.")
+    private Long receiverId;
 
     @NotBlank(message = "메시지가 누락되었거나, 공백입니다.")
     @Size(min = 10, max = 300, message = "채팅의 최소 글자 수는 10, 최대 300자 입니다.")
@@ -23,11 +26,17 @@ public class ChatMessageCreateRequestDto{
     @NotNull(message = "채팅방 아이디가 누락되었습니다.")
     private Long roomId;
 
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @NotNull(message = "채팅 전송 시간이 누락되었습니다.")
+    private LocalDateTime createTime;
+
+
     public ChatMessage toEntity(ChatRoom chatRoom, Employee employee){
         return ChatMessage.builder()
                 .employee(employee)
                 .chatRoom(chatRoom)
                 .message(message)
+                .createTime(createTime)
                 .build();
     }
 }

--- a/src/main/java/com/example/chulgunhazabackend/dto/chat/ChatMessageListResponseDto.java
+++ b/src/main/java/com/example/chulgunhazabackend/dto/chat/ChatMessageListResponseDto.java
@@ -1,12 +1,10 @@
 package com.example.chulgunhazabackend.dto.chat;
 
 import com.example.chulgunhazabackend.domain.chat.ChatMessage;
-import com.example.chulgunhazabackend.domain.member.Employee;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 @AllArgsConstructor
@@ -20,14 +18,18 @@ public class ChatMessageListResponseDto {
 
     private Long RoomId;
 
-    private LocalDateTime createdAt;
+    private LocalDateTime createdTime;
+
+    private boolean isRead;
+
 
     public ChatMessageListResponseDto fromEntity(ChatMessage chatMessage) {
         return new ChatMessageListResponseDto(
                 chatMessage.getEmployee().getId()
                 , chatMessage.getMessage()
                 , chatMessage.getChatRoom().getId()
-                , chatMessage.getCreatedAt()
+                , chatMessage.getCreateTime()
+                , chatMessage.isRead()
         );
     }
 }

--- a/src/main/java/com/example/chulgunhazabackend/dto/chat/ChatNotificationDto.java
+++ b/src/main/java/com/example/chulgunhazabackend/dto/chat/ChatNotificationDto.java
@@ -1,6 +1,5 @@
 package com.example.chulgunhazabackend.dto.chat;
 
-import com.example.chulgunhazabackend.domain.member.Position;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,16 +11,16 @@ import java.io.Serializable;
 @NoArgsConstructor
 public class ChatNotificationDto implements Serializable {
 
-    public Long employeeNo;
+    public Long roomId;
 
-    public String name;
+    public Long senderEmployeeNo;
 
-    public String department;
+    public String senderName;
 
-    public Position position;
+    public Long receiverEmployeeNo;
 
-    public String message;
+    public String lastMessage;
 
-    // TODO: 채팅 방 찾는 링크 추가
+    public Long unReadMessageCount;
 
 }

--- a/src/main/java/com/example/chulgunhazabackend/dto/chat/ChatRoomListResponseDto.java
+++ b/src/main/java/com/example/chulgunhazabackend/dto/chat/ChatRoomListResponseDto.java
@@ -1,23 +1,46 @@
 package com.example.chulgunhazabackend.dto.chat;
 
-import com.example.chulgunhazabackend.domain.chat.ChatRoom;
 import com.example.chulgunhazabackend.domain.chat.EmployeeChatRoom;
+import com.example.chulgunhazabackend.domain.member.Position;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @Getter
 @NoArgsConstructor
 public class ChatRoomListResponseDto {
 
-    private Long EmployeeChatRoomId;
+    private Long roomId;
 
-    private Long userId;
+    private Long employeeId;
+
+    private Long employeeNo;
 
     private String userName;
 
-    public ChatRoomListResponseDto fromEntity(EmployeeChatRoom employeeChatRoom) {
-        return new ChatRoomListResponseDto(employeeChatRoom.getId(), employeeChatRoom.getEmployee().getEmployeeNo(), employeeChatRoom.getEmployee().getName());
+    private Position position;
+
+    private String department;
+
+    private String lastMessage;
+
+    private Long unReadMessageCount;
+
+    private LocalDateTime lastMessageTime;
+
+    public ChatRoomListResponseDto fromEntity(EmployeeChatRoom employeeChatRoom, String lastMessage, Long unReadMessageCount, LocalDateTime lastMessageTime) {
+        return new ChatRoomListResponseDto(employeeChatRoom.getId()
+                , employeeChatRoom.getEmployee().getId()
+                , employeeChatRoom.getEmployee().getEmployeeNo()
+                , employeeChatRoom.getEmployee().getName()
+                , employeeChatRoom.getEmployee().getPosition()
+                , employeeChatRoom.getEmployee().getDepartment()
+                , lastMessage
+                , unReadMessageCount
+                , lastMessageTime
+        );
     }
 }

--- a/src/main/java/com/example/chulgunhazabackend/event/chat/event/ChatCreateEvent.java
+++ b/src/main/java/com/example/chulgunhazabackend/event/chat/event/ChatCreateEvent.java
@@ -1,4 +1,28 @@
 package com.example.chulgunhazabackend.event.chat.event;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@AllArgsConstructor
 public class ChatCreateEvent {
+
+    private final Long roomId;
+
+    private final Long senderId;
+
+    private final String senderName;
+
+    private final Long receiverId;
+
+    private final String message;
+
+    private final LocalDateTime creatTime;
+
+    private final long unReadMessageCount;
+
 }

--- a/src/main/java/com/example/chulgunhazabackend/event/chat/event/ChatCreateEvent.java
+++ b/src/main/java/com/example/chulgunhazabackend/event/chat/event/ChatCreateEvent.java
@@ -1,0 +1,4 @@
+package com.example.chulgunhazabackend.event.chat.event;
+
+public class ChatCreateEvent {
+}

--- a/src/main/java/com/example/chulgunhazabackend/event/chat/handler/ChatCreateEventHandler.java
+++ b/src/main/java/com/example/chulgunhazabackend/event/chat/handler/ChatCreateEventHandler.java
@@ -1,0 +1,4 @@
+package com.example.chulgunhazabackend.event.common;
+
+public class ChatCreateEventHandler {
+}

--- a/src/main/java/com/example/chulgunhazabackend/event/chat/handler/ChatCreateEventHandler.java
+++ b/src/main/java/com/example/chulgunhazabackend/event/chat/handler/ChatCreateEventHandler.java
@@ -1,4 +1,35 @@
-package com.example.chulgunhazabackend.event.common;
+package com.example.chulgunhazabackend.event.chat.handler;
 
+import com.example.chulgunhazabackend.dto.chat.ChatNotificationDto;
+import com.example.chulgunhazabackend.event.chat.event.ChatCreateEvent;
+import com.example.chulgunhazabackend.repository.ChatMessageRepository;
+import com.example.chulgunhazabackend.service.ChatAlarmService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class ChatCreateEventHandler {
+
+    private final ChatAlarmService chatAlarmService;
+
+    @EventListener
+    public void handleChatCreateEvent(ChatCreateEvent event) throws IOException {
+
+        ChatNotificationDto dto = new ChatNotificationDto(
+                event.getRoomId()
+                , event.getSenderId()
+                , event.getSenderName()
+                , event.getReceiverId()
+                , event.getMessage()
+                , event.getUnReadMessageCount() + 1
+        );
+
+        chatAlarmService.sendSseEvent(dto);
+    }
 }

--- a/src/main/java/com/example/chulgunhazabackend/listener/ChatMessageListener.java
+++ b/src/main/java/com/example/chulgunhazabackend/listener/ChatMessageListener.java
@@ -1,0 +1,4 @@
+package com.example.chulgunhazabackend.listener;
+
+public class ChatMessageListener {
+}

--- a/src/main/java/com/example/chulgunhazabackend/listener/ChatMessageListener.java
+++ b/src/main/java/com/example/chulgunhazabackend/listener/ChatMessageListener.java
@@ -1,4 +1,38 @@
 package com.example.chulgunhazabackend.listener;
 
+import com.example.chulgunhazabackend.dto.chat.ChatMessageCreateRMQDto;
+import com.example.chulgunhazabackend.exception.chatException.ChatException;
+import com.example.chulgunhazabackend.exception.employeeException.EmployeeException;
+import com.example.chulgunhazabackend.service.ChatMessageService;
+import com.rabbitmq.client.Channel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class ChatMessageListener {
+
+    private final ChatMessageService chatMessageService;
+
+    @RabbitListener(queues = "chulgunhazabackend_chat_queue")
+    public void saveChatMessage(@Payload ChatMessageCreateRMQDto chatMessageCreateRMQDto,
+                                Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag) throws IOException {
+        try{
+            chatMessageService.saveChatMessage(chatMessageCreateRMQDto);
+            log.info("save Message : " + chatMessageCreateRMQDto.getMessage() + " : " + chatMessageCreateRMQDto.getRoomId());
+
+        }catch(NullPointerException e){
+            channel.basicNack(tag, false, false); // 큐에 있는 메세지 삭제
+        }catch(ChatException | EmployeeException e){
+            channel.basicNack(tag, false, false);
+        }
+    }
 }

--- a/src/main/java/com/example/chulgunhazabackend/listener/NotificationListener.java
+++ b/src/main/java/com/example/chulgunhazabackend/listener/NotificationListener.java
@@ -2,11 +2,17 @@ package com.example.chulgunhazabackend.listener;
 
 import com.example.chulgunhazabackend.dto.chat.ChatNotificationDto;
 import com.example.chulgunhazabackend.service.ChatAlarmService;
+import com.rabbitmq.client.Channel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
 
 @Slf4j
 @Component
@@ -17,9 +23,14 @@ public class NotificationListener {
 
     // INFO: Chat Notification Queue 의 Listener 입니다.
     @RabbitListener(queues = "chulgunhazabackend_notification_queue")
-    public void receiveChatNotification(@Payload ChatNotificationDto chatNotificationDto) {
-        chatAlarmService.sendSseEvent(chatNotificationDto);
-        log.info("send Chat Alarm to : " + chatNotificationDto.employeeNo);
-    }
+    public void receiveChatNotification(@Payload ChatNotificationDto chatNotificationDto,
+                                            Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag) throws IOException {
+        try{
+            chatAlarmService.sendSseEvent(chatNotificationDto);
+            log.info("send Chat Alarm to : " + chatNotificationDto.roomId);
+        }catch (Exception e){
+            channel.basicNack(tag, false, false);
+        }
 
+    }
 }

--- a/src/main/java/com/example/chulgunhazabackend/repository/ChatMessageRepository.java
+++ b/src/main/java/com/example/chulgunhazabackend/repository/ChatMessageRepository.java
@@ -5,11 +5,23 @@ import com.example.chulgunhazabackend.domain.chat.ChatRoom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
-import java.util.Optional;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
     Page<ChatMessage> findByChatRoomOrderByCreatedAtDesc(ChatRoom chatRoom, Pageable pageable);
+
+    @Query(value = "SELECT * FROM chat_message WHERE room_id = :roomId ORDER BY create_time DESC LIMIT 1", nativeQuery = true)
+    ChatMessage findByChatRoomLastMessage(Long roomId);
+
+
+    @Query(value = "SELECT COUNT(*) FROM chat_message WHERE room_id = :roomId AND is_read = false  AND employee_id <> :employeeId", nativeQuery = true)
+    Long findByIsReadCount(Long roomId, Long employeeId);
+
+    @Modifying
+    @Query(value = "UPDATE chat_message c SET c.is_read = true WHERE room_id = :roomId AND employee_id <> :employeeId AND is_read = false", nativeQuery = true)
+    void updateByChatRoomAndNotSendUserMessage(Long roomId, Long employeeId);
 
 }

--- a/src/main/java/com/example/chulgunhazabackend/repository/EmployeeChatRoomRepository.java
+++ b/src/main/java/com/example/chulgunhazabackend/repository/EmployeeChatRoomRepository.java
@@ -20,6 +20,11 @@ public interface EmployeeChatRoomRepository extends JpaRepository<EmployeeChatRo
             "AND ec2.employee.id = :receiverId" )
     Optional<Long> findRoomIdByEmployeeIds(@Param("senderId") Long senderId, @Param("receiverId") Long receiverId);
 
+    @Query("SELECT c FROM EmployeeChatRoom c WHERE c.chatRoom.id IN " +
+            "(SELECT cr.chatRoom.id FROM EmployeeChatRoom cr WHERE cr.employee.id = :employeeId) " +
+            "AND c.employee.id != :employeeId")
+    Page<EmployeeChatRoom> findChatRoomsExcludingEmployee(@Param("employeeId") Long employeeId, Pageable pageable);
+
     Optional<EmployeeChatRoom> findByEmployeeIdAndChatRoomId(Long employeeId, Long chatRoomId);
 
 }

--- a/src/main/java/com/example/chulgunhazabackend/security/interceptor/SecurityContextInterceptor.java
+++ b/src/main/java/com/example/chulgunhazabackend/security/interceptor/SecurityContextInterceptor.java
@@ -1,0 +1,31 @@
+package com.example.chulgunhazabackend.security.interceptor;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeFailureException;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+public class SecurityContextInterceptor implements HandshakeInterceptor {
+
+    // INFO: WebSocket Session 에 HttpSession 의 SecurityContext 를 추가하기 위한 로직
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws HandshakeFailureException {
+
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+
+        if(securityContext != null && securityContext.getAuthentication() != null) {
+            attributes.put("SPRING_SECURITY_CONTEXT", securityContext);
+        }
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+        // INFO: 필요 시 추가 처리 가능
+    }
+}

--- a/src/main/java/com/example/chulgunhazabackend/service/ChatMessageService.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/ChatMessageService.java
@@ -1,14 +1,15 @@
 package com.example.chulgunhazabackend.service;
 
 import com.example.chulgunhazabackend.dto.PageDto;
+import com.example.chulgunhazabackend.dto.chat.ChatMessageCreateRMQDto;
 import com.example.chulgunhazabackend.dto.chat.ChatMessageCreateRequestDto;
 import com.example.chulgunhazabackend.dto.chat.ChatMessageListResponseDto;
 import org.springframework.data.domain.Pageable;
 
 public interface ChatMessageService {
 
-    Long saveChatMessage(ChatMessageCreateRequestDto chatMessageCreateRequestDto);
+    Long saveChatMessage(ChatMessageCreateRMQDto chatMessageCreateRMQDto);
 
-    PageDto<ChatMessageListResponseDto> getChatMessagesByRoomId(Long roomId, Pageable pageable);
+    PageDto<ChatMessageListResponseDto> getChatMessagesByRoomId(Long roomId, Long employeeId, Pageable pageable);
 
 }

--- a/src/main/java/com/example/chulgunhazabackend/service/ChatRabbitMQMessageService.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/ChatRabbitMQMessageService.java
@@ -1,8 +1,11 @@
 package com.example.chulgunhazabackend.service;
 
+import com.example.chulgunhazabackend.dto.chat.ChatMessageCreateRequestDto;
 import com.example.chulgunhazabackend.dto.chat.ChatNotificationDto;
 
 public interface ChatRabbitMQMessageService {
 
     void sendNotification(ChatNotificationDto chatNotificationDto);
+
+    String sendChatMessage(ChatMessageCreateRequestDto chatMessageCreateRequestDto, Long senderId);
 }

--- a/src/main/java/com/example/chulgunhazabackend/service/ChatRoomService.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/ChatRoomService.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface ChatRoomService {
 
-    Long saveChatRoom(ChatRoomCreateRequestDto chatRoomCreateRequestDto);
+    Long saveChatRoom(ChatRoomCreateRequestDto chatRoomCreateRequestDto, Long employeeId);
 
     PageDto<ChatRoomListResponseDto> getAllChatRoomsByEmployeeId(Long employeeId, Pageable pageable);
 

--- a/src/main/java/com/example/chulgunhazabackend/service/impl/ChatAlarmServiceImpl.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/impl/ChatAlarmServiceImpl.java
@@ -12,7 +12,6 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.io.IOException;
 
 
-//HACK : 추 후 유실가능성이 있는 Sse Alarm 에 대해 처리가 필요합니다.
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -22,26 +21,24 @@ public class ChatAlarmServiceImpl implements ChatAlarmService {
 
     //INFO: Chat Sse 를 구독하는 로직입니다. 세부 로직 -> SseEmitterManager
     @Override
-    public SseEmitter subscribe(Long employeeNo) throws IOException {
-        return sseEmitterManager.chatRegisterEmitter(employeeNo);
+    public SseEmitter subscribe(Long employeeId) throws IOException {
+        return sseEmitterManager.chatRegisterEmitter(employeeId);
     }
 
     //INFO : 구독 중이라면 전송하는 로직입니다.
     @Async
     @Override
     public void sendSseEvent(ChatNotificationDto chatNotificationDto) {
-        SseEmitter emitter = sseEmitterManager.getChatEmitter(chatNotificationDto.getEmployeeNo());
+        SseEmitter emitter = sseEmitterManager.getChatEmitter(chatNotificationDto.getReceiverEmployeeNo());
         if (emitter != null){
             try{
-                // HACK: 신규 구독 시 쌓여 있던 알람을 보내주는 로직을 추가합니다.
                 emitter.send(SseEmitter.event().data(chatNotificationDto));
                 log.info("send from ChatAlarmService Send sendSseEvent Method");
             } catch (IOException e) {
                 log.info("Occur error from ChatAlarmService Send sendSseEvent Method");
-                sseEmitterManager.removeChatEmitter(chatNotificationDto.getEmployeeNo());
+                sseEmitterManager.removeChatEmitter(chatNotificationDto.getReceiverEmployeeNo());
             }
         }else {
-            //HACK: 구독중이 아니라면 DB에 알람을 저장을 저장하는 로직을 추가합니다.
             log.info("emitter is null");
         }
     }

--- a/src/main/java/com/example/chulgunhazabackend/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/impl/ChatMessageServiceImpl.java
@@ -5,9 +5,8 @@ import com.example.chulgunhazabackend.domain.chat.ChatRoom;
 import com.example.chulgunhazabackend.domain.chat.EmployeeChatRoom;
 import com.example.chulgunhazabackend.domain.member.Employee;
 import com.example.chulgunhazabackend.dto.PageDto;
-import com.example.chulgunhazabackend.dto.chat.ChatMessageCreateRequestDto;
+import com.example.chulgunhazabackend.dto.chat.ChatMessageCreateRMQDto;
 import com.example.chulgunhazabackend.dto.chat.ChatMessageListResponseDto;
-import com.example.chulgunhazabackend.dto.chat.ChatNotificationDto;
 import com.example.chulgunhazabackend.exception.chatException.ChatException;
 import com.example.chulgunhazabackend.exception.chatException.ChatExceptionType;
 import com.example.chulgunhazabackend.exception.employeeException.EmployeeException;
@@ -17,12 +16,12 @@ import com.example.chulgunhazabackend.repository.ChatRoomRepository;
 import com.example.chulgunhazabackend.repository.EmployeeChatRoomRepository;
 import com.example.chulgunhazabackend.repository.EmployeeRepository;
 import com.example.chulgunhazabackend.service.ChatMessageService;
-import com.example.chulgunhazabackend.service.ChatRabbitMQMessageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 
 @Service
@@ -34,37 +33,41 @@ public class ChatMessageServiceImpl implements ChatMessageService {
     private final ChatRoomRepository chatRoomRepository;
     private final EmployeeRepository employeeRepository;
     private final EmployeeChatRoomRepository employeeChatRoomRepository;
-    private final ChatRabbitMQMessageService chatRabbitMQMessageService;
 
     @Override
-    public Long saveChatMessage(ChatMessageCreateRequestDto chatMessageCreateRequestDto) {
+    public Long saveChatMessage(ChatMessageCreateRMQDto chatMessageCreateRMQDto) {
 
         // INFO: 채팅방 존재 유무 확인
-        ChatRoom chatRoom = chatRoomRepository.findById(chatMessageCreateRequestDto.getRoomId()).orElseThrow(() -> new ChatException(ChatExceptionType.NOT_FOUND_CHAT_ROOM));
+        ChatRoom chatRoom = chatRoomRepository.findById(chatMessageCreateRMQDto.getRoomId()).orElseThrow(() -> new ChatException(ChatExceptionType.NOT_FOUND_CHAT_ROOM));
 
-        // INFO: 전송하는 사원의 유무 확인
-        // HACK : employeeNO 로 찾아오는 로직으로 변경 예정
-        Employee employee = employeeRepository.findEmployeeById(chatMessageCreateRequestDto.getSenderId()).orElseThrow(() -> new EmployeeException(EmployeeExceptionType.NOT_EXIST_USER));
+        // INFO: 전송하는 사원의 정보
+        Employee sendEmployee = employeeRepository.findEmployeeById(chatMessageCreateRMQDto.getSenderId()).orElseThrow(() -> new EmployeeException(EmployeeExceptionType.NOT_EXIST_USER));
+
+        // INFO: 전송받는 사원의 유무 확인
+        Employee receiveEmployee = employeeRepository.findEmployeeById(chatMessageCreateRMQDto.getReceiverId()).orElseThrow(() -> new EmployeeException(EmployeeExceptionType.NOT_EXIST_USER));
 
         // INFO: 채팅방 인원이 아닌데 전송하는 경우 예외 처리
-        // HACK: employeeNO 로 찾아오는 로직으로 변경 예정
-        EmployeeChatRoom employeeChatRoom = employeeChatRoomRepository.findByEmployeeIdAndChatRoomId(employee.getId(), chatRoom.getId()).orElseThrow(() -> new ChatException(ChatExceptionType.NOT_FOUND_CHAT_USER));
+        EmployeeChatRoom employeeChatRoom = employeeChatRoomRepository.findByEmployeeIdAndChatRoomId(sendEmployee.getId(), chatRoom.getId()).orElseThrow(() -> new ChatException(ChatExceptionType.NOT_FOUND_CHAT_USER));
 
-        // HACK: 오프라인 유저, 온라인 유저 구분 로직 추가 시 로직 변경 예정
-        chatRabbitMQMessageService.sendNotification(new ChatNotificationDto(employee.getEmployeeNo(), employee.getName(), employee.getDepartment(), employee.getPosition(), employee.getEmployeeNo() + " 님 에게서 메시지가 도착했습니다."));
-
-        return chatMessageRepository.save(chatMessageCreateRequestDto.toEntity(chatRoom, employee)).getId();
+        return chatMessageRepository.save(chatMessageCreateRMQDto.toEntity(chatRoom, sendEmployee)).getId();
     }
 
     @Override
-    public PageDto<ChatMessageListResponseDto> getChatMessagesByRoomId(Long roomId, Pageable pageable) {
+    public PageDto<ChatMessageListResponseDto> getChatMessagesByRoomId(Long roomId, Long employeeId, Pageable pageable) {
 
-        // 채팅방의 존재 유무
+        // INFO : 채팅방 존재 유무 확인
         ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElseThrow(() -> new ChatException(ChatExceptionType.NOT_FOUND_CHAT_ROOM));
 
+        // INFO : 채팅방 별 메시지 가져오기
         Page<ChatMessage> contents = chatMessageRepository.findByChatRoomOrderByCreatedAtDesc(chatRoom, pageable);
 
+        // INFO : 채팅방 읽음 처리
+        // HACK : 추후 배치 처리 필요.
+        chatMessageRepository.updateByChatRoomAndNotSendUserMessage(roomId, employeeId);
+
+        // INFO : PAGING
         Page<ChatMessageListResponseDto> pageDto = contents.map(chatMessage -> new ChatMessageListResponseDto().fromEntity(chatMessage));
+
 
         return new PageDto<>(pageDto) ;
     }

--- a/src/main/java/com/example/chulgunhazabackend/service/impl/ChatRabbitMQMessageServiceImpl.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/impl/ChatRabbitMQMessageServiceImpl.java
@@ -1,11 +1,29 @@
 package com.example.chulgunhazabackend.service.impl;
 
+import com.example.chulgunhazabackend.config.RabbitMQConfig;
+import com.example.chulgunhazabackend.domain.member.Employee;
+import com.example.chulgunhazabackend.dto.chat.ChatMessageCreateRMQDto;
+import com.example.chulgunhazabackend.dto.chat.ChatMessageCreateRequestDto;
 import com.example.chulgunhazabackend.dto.chat.ChatNotificationDto;
+import com.example.chulgunhazabackend.event.chat.event.ChatCreateEvent;
+import com.example.chulgunhazabackend.exception.employeeException.EmployeeException;
+import com.example.chulgunhazabackend.exception.employeeException.EmployeeExceptionType;
+import com.example.chulgunhazabackend.repository.ChatMessageRepository;
+import com.example.chulgunhazabackend.repository.EmployeeRepository;
 import com.example.chulgunhazabackend.service.ChatRabbitMQMessageService;
+import com.example.chulgunhazabackend.service.sse.SseEmitterManager;
+import com.example.chulgunhazabackend.websocket.handler.WebSocketMessageHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
 
 @Slf4j
 @Service
@@ -13,12 +31,70 @@ import org.springframework.stereotype.Service;
 public class ChatRabbitMQMessageServiceImpl implements ChatRabbitMQMessageService {
 
     private final RabbitTemplate rabbitTemplate;
+    private final WebSocketMessageHandler webSocketMessageHandler;
+    private final ObjectMapper objectMapper;
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final ChatMessageRepository chatMessageRepository;
+    private final SseEmitterManager sseEmitterManager;
+    private final EmployeeRepository employeeRepository;
 
     //INFO : 채팅 알람 발생 시 RMQ 로 메시지 전송
     public void sendNotification(ChatNotificationDto chatNotificationDto){
-        String routingKey = "chat_notification_queue_key";
-        rabbitTemplate.convertAndSend("chulgunhazabackend_chat", routingKey, chatNotificationDto);
+        rabbitTemplate.convertAndSend(RabbitMQConfig.CHAT_EXCHANGE_NAME, RabbitMQConfig.CHAT_NOTIFICATION_ROUTING_KEY, chatNotificationDto);
         log.info("Sending notification to RabbitMQ");
+    }
+
+    // INFO: 채팅 저장 RMQ 전송
+    public String sendChatMessage(ChatMessageCreateRequestDto chatMessageCreateRequestDto, Long senderId){
+
+        // INFO : RMQ 로 전송을 위한 데이터 바인딩
+        ChatMessageCreateRMQDto dto = new ChatMessageCreateRMQDto(
+                senderId
+                , chatMessageCreateRequestDto.getReceiverId()
+                , chatMessageCreateRequestDto.getMessage()
+                , chatMessageCreateRequestDto.getRoomId()
+                , chatMessageCreateRequestDto.getCreateTime());
+
+        // INFO : RMQ 전송
+        rabbitTemplate.convertAndSend(RabbitMQConfig.CHAT_EXCHANGE_NAME
+                , RabbitMQConfig.CHAT_ROUTING_KEY
+                , dto);
+
+        // INFO : ChatRoom 관련 session 이 존재하면 전송
+        // HACK : 추후 Listener 내부로 로직 리펙토링 가능.
+        WebSocketSession session = webSocketMessageHandler.getSession(chatMessageCreateRequestDto.getReceiverId(), chatMessageCreateRequestDto.getRoomId());
+        log.info(String.valueOf(session));
+        if(session != null){
+            try {
+                session.sendMessage(new TextMessage(objectMapper.writeValueAsString(chatMessageCreateRequestDto)));
+            } catch (IOException e) {
+                log.info(e.getMessage());
+            }
+        }else{
+            // INFO : 그렇지 않다면 알람 전송
+            log.info("session is null -> change sse session");
+
+            if(sseEmitterManager.getChatEmitter(chatMessageCreateRequestDto.getReceiverId()) != null){
+                Employee senderEmployee = employeeRepository.findEmployeeById(senderId).orElseThrow(() -> new EmployeeException(EmployeeExceptionType.NOT_EXIST_USER));
+                long unReadMessageCount = chatMessageRepository.findByIsReadCount(chatMessageCreateRequestDto.getRoomId(), senderId);
+
+                // INFO event 발행
+                applicationEventPublisher.publishEvent(new ChatCreateEvent(
+                        chatMessageCreateRequestDto.getRoomId()
+                        , senderEmployee.getEmployeeNo()
+                        , senderEmployee.getName()
+                        , chatMessageCreateRequestDto.getReceiverId()
+                        , chatMessageCreateRequestDto.getMessage()
+                        , chatMessageCreateRequestDto.getCreateTime()
+                        , unReadMessageCount
+                ));
+            }
+
+        }
+
+        log.info("Sending chat message to RabbitMQ");
+
+        return "전송 완료";
     }
 
 }

--- a/src/main/java/com/example/chulgunhazabackend/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/impl/ChatRoomServiceImpl.java
@@ -10,12 +10,14 @@ import com.example.chulgunhazabackend.exception.chatException.ChatException;
 import com.example.chulgunhazabackend.exception.chatException.ChatExceptionType;
 import com.example.chulgunhazabackend.exception.employeeException.EmployeeException;
 import com.example.chulgunhazabackend.exception.employeeException.EmployeeExceptionType;
+import com.example.chulgunhazabackend.repository.ChatMessageRepository;
 import com.example.chulgunhazabackend.repository.ChatRoomRepository;
 import com.example.chulgunhazabackend.repository.EmployeeChatRoomRepository;
 import com.example.chulgunhazabackend.repository.EmployeeRepository;
 import com.example.chulgunhazabackend.service.ChatRoomService;
 import com.example.chulgunhazabackend.service.EmployeeChatRoomService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -24,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -33,44 +36,51 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     private final EmployeeRepository employeeRepository;
     private final EmployeeChatRoomService employeeChatRoomService;
     private final EmployeeChatRoomRepository employeeChatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
 
     @Override
-    public Long saveChatRoom(ChatRoomCreateRequestDto chatRoomCreateRequestDto) {
+    public Long saveChatRoom(ChatRoomCreateRequestDto chatRoomCreateRequestDto, Long employeeId) {
 
-        // 생성된 채팅방인지 검증
-        Optional<Long> id = employeeChatRoomRepository.findRoomIdByEmployeeIds(chatRoomCreateRequestDto.getSenderId(), chatRoomCreateRequestDto.getReceiverId());
+        // INFO : 생성된 채팅방인지 검증
+        Optional<Long> id = employeeChatRoomRepository.findRoomIdByEmployeeIds(employeeId, chatRoomCreateRequestDto.getReceiverId());
 
-        //존재 시 예외 발생
+        // INFO : 존재 시 예외 발생
         if(id.isPresent()){
             throw new ChatException(ChatExceptionType.ALREADY_CHAT_ROOM);
         }
 
-        //존재 하지 않을 시 새로운 채팅 방 생성
+        // INFO : 존재 하지 않을 시 새로운 채팅 방 생성
         ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.builder().build());
 
-        // 전송자, 수신자 아이디를 새로운 채팅방에 추가
+        // INFO : 전송자, 수신자 아이디를 새로운 채팅방에 추가
         Employee senderEmployee = employeeRepository.findEmployeeById(chatRoomCreateRequestDto.getSenderId()).orElseThrow(()
                 -> new EmployeeException(EmployeeExceptionType.NOT_EXIST_USER));
 
         Employee receiverEmployee = employeeRepository.findEmployeeById(chatRoomCreateRequestDto.getReceiverId()).orElseThrow(()
                 -> new EmployeeException(EmployeeExceptionType.NOT_EXIST_USER));
 
-        // 관련 채팅방에 유저 저장 로직
+        // INFO : 관련 채팅방에 유저 저장 로직
         employeeChatRoomService.save(chatRoom, senderEmployee, receiverEmployee);
 
         return chatRoom.getId();
         
     }
 
-    // // 전송 사원의 아이디로 해당 사원의 채팅방 목록 가져오기
+    // INFO : 전송 사원의 아이디로 해당 사원의 채팅방 목록 가져오기
     @Override
     public PageDto<ChatRoomListResponseDto> getAllChatRoomsByEmployeeId(Long employeeId, Pageable pageable) {
 
-        // 사원이 속한 채팅 방을 가져오는 로직
+        // INFO : 사원이 속한 채팅 방을 가져오는 로직
         Page<EmployeeChatRoom> contents = employeeChatRoomService.findByEmployeeId(employeeId, pageable);
 
-        // 가져온 데이터를 PageDto 에 넣기 위한 타입으로 변환
-        Page<ChatRoomListResponseDto> list =  contents.map(employeeChatRoom -> new ChatRoomListResponseDto().fromEntity(employeeChatRoom));
+
+
+        // INFO : 가져온 데이터를 PageDto 에 넣기 위한 타입으로 변환
+        Page<ChatRoomListResponseDto> list =  contents.map(employeeChatRoom -> new ChatRoomListResponseDto()
+                .fromEntity( employeeChatRoom
+                            , chatMessageRepository.findByChatRoomLastMessage(employeeChatRoom.getChatRoom().getId()).getMessage()
+                            , chatMessageRepository.findByIsReadCount(employeeChatRoom.getChatRoom().getId(), employeeId)
+                            , chatMessageRepository.findByChatRoomLastMessage(employeeChatRoom.getChatRoom().getId()).getCreateTime()));
 
         return new PageDto<ChatRoomListResponseDto>(list);
 

--- a/src/main/java/com/example/chulgunhazabackend/service/impl/EmployeeChatRoomServiceImpl.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/impl/EmployeeChatRoomServiceImpl.java
@@ -21,18 +21,18 @@ public class EmployeeChatRoomServiceImpl implements EmployeeChatRoomService {
     @Override
     public Long save(ChatRoom chatRoom, Employee senderEmployee, Employee receiverEmployee) {
 
-        //senderEmployee 저장
+        // INFO : senderEmployee 저장
         employeeChatRoomRepository.save(EmployeeChatRoom.builder().chatRoom(chatRoom).employee(senderEmployee).build());
 
-        //receiverEmployee 저장
+        // INFO : receiverEmployee 저장
         employeeChatRoomRepository.save(EmployeeChatRoom.builder().chatRoom(chatRoom).employee(receiverEmployee).build());
 
         return chatRoom.getId();
     }
 
-    // 전송 사원의 아이디로 해당 사원의 채팅방 목록 가져오기
+    // INFO : 전송 사원의 아이디로 해당 사원의 채팅방 목록 가져오기
     @Override
     public Page<EmployeeChatRoom> findByEmployeeId(Long employeeId, Pageable pageable) {
-        return employeeChatRoomRepository.findByEmployeeId(employeeId, pageable);
+        return employeeChatRoomRepository.findChatRoomsExcludingEmployee(employeeId, pageable);
     }
 }

--- a/src/main/java/com/example/chulgunhazabackend/service/sse/SseEmitterManager.java
+++ b/src/main/java/com/example/chulgunhazabackend/service/sse/SseEmitterManager.java
@@ -11,7 +11,6 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 public class SseEmitterManager {
 
-    // HACK : 추후 Singleton 적용 후 Config 로 분리 Manager 와 Config 를 분리해서 사용.
     private final Map<EmitterType, Map<Long, SseEmitter>> emitters = new ConcurrentHashMap<>();
 
     // INFO: Emitter type 은 Main 과 chat 2가지 입니다.
@@ -28,14 +27,15 @@ public class SseEmitterManager {
     }
 
     // INFO: chatEmitter 를 등록하고 반환하는 메서드 입니다.
-    public SseEmitter chatRegisterEmitter(Long employeeNo) {
+    // HACK: 추후 Emitter 시간 조정 필요.
+    public SseEmitter chatRegisterEmitter(Long employeeId) {
 
         SseEmitter emitter = new SseEmitter(10000000L);
-        emitters.get(EmitterType.CHAT).put(employeeNo, emitter);
-        emitter.onCompletion(() -> emitters.get(EmitterType.CHAT).remove(employeeNo));
-        emitter.onTimeout(() -> emitters.get(EmitterType.CHAT).remove(employeeNo));
+        emitters.get(EmitterType.CHAT).put(employeeId, emitter);
+        emitter.onCompletion(() -> emitters.get(EmitterType.CHAT).remove(employeeId));
+        emitter.onTimeout(() -> emitters.get(EmitterType.CHAT).remove(employeeId));
 
-        sendEmitterData(EmitterType.CHAT, emitter, employeeNo, "ChatSseConnect", "Success Chat SSE");
+        sendEmitterData(EmitterType.CHAT, emitter, employeeId, "ChatSseConnect", "Success Chat SSE");
         return emitter;
 
     }
@@ -49,8 +49,6 @@ public class SseEmitterManager {
        sendEmitterData(EmitterType.MAIN, emitter, employeeNo, "MainSseConnect", "Success Main SSE");
        return emitter;
    }
-
-
 
     // INFO: chatEmitter 를 가져오는 로직
     public SseEmitter getChatEmitter(Long employeeNo) {

--- a/src/main/java/com/example/chulgunhazabackend/websocket/handler/WebSocketMessageHandler.java
+++ b/src/main/java/com/example/chulgunhazabackend/websocket/handler/WebSocketMessageHandler.java
@@ -1,6 +1,8 @@
 package com.example.chulgunhazabackend.websocket.handler;
 
 import com.example.chulgunhazabackend.dto.Employee.EmployeeCredentialDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -11,6 +13,7 @@ import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
 
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
@@ -24,27 +27,37 @@ public class WebSocketMessageHandler implements WebSocketHandler {
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
 
         // INFO : 인증된 유저의 정보를 가져와서 ConcurrentHashMap 에 저장을 합니다.
-        // HACK : 우선 웹 소캣 통신에 대한 기반을 잡아두고 Redis Session Storage 에 저장하는 로직을 작성 예정, 다만 Emitter 처럼 Redis 에 직렬화 해서 넣기가 애매 함.
-        SecurityContext securityContext = (SecurityContext) session.getAttributes().get("SPRING_SECURITY_CONTEXT");
-        if(securityContext != null) {
-            Authentication authentication = securityContext.getAuthentication();
-            if(authentication != null && authentication.isAuthenticated()) {
-                EmployeeCredentialDto credentialDto = (EmployeeCredentialDto) authentication.getPrincipal();
-                sessions.put(credentialDto.getId(), new ConcurrentHashMap<>());
-                log.info("Websocket Connected for user " + credentialDto.getId());
-            }else {
-                session.close(CloseStatus.NOT_ACCEPTABLE);
-                log.warn("Failed to connect to websocket, no Authentication");
-            }
-        }else{
+        EmployeeCredentialDto credentialDto = getAuthenticatedUser(session);
+        if (credentialDto != null) {
+            sessions.putIfAbsent(credentialDto.getId(), new ConcurrentHashMap<>());
+            log.info("WebSocket Connected for user {}", credentialDto.getId());
+        } else {
             session.close(CloseStatus.NOT_ACCEPTABLE);
-            log.warn("WebSocket connection attempt failed. SecurityContext is missing.");
+            log.warn("Failed to connect to websocket, no Authentication");
         }
     }
 
     @Override
     public void handleMessage(WebSocketSession session, WebSocketMessage<?> message) throws Exception {
-        //INFO : Client 로 부터 받은 메시지를 처리할 수 있음.
+        //INFO : Client 로 부터 접속 중인 채팅방 정보 받아서 처리
+        String payload = message.getPayload().toString();
+        log.info("Received message: {}", payload);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(payload);
+        String type = jsonNode.get("type").asText();
+        Long chatRoomId = jsonNode.get("chatRoomId").asLong();
+
+        EmployeeCredentialDto credentialDto = getAuthenticatedUser(session);
+        if (credentialDto != null) {
+            Long userId = credentialDto.getId();
+
+            if ("subscribe".equals(type)) {
+                subscribeToChatRoom(userId, chatRoomId, session);
+            } else if ("unsubscribe".equals(type)) {
+                unsubscribeFromChatRoom(userId, chatRoomId);
+            }
+        }
     }
 
     @Override
@@ -70,7 +83,44 @@ public class WebSocketMessageHandler implements WebSocketHandler {
         return false;
     }
 
+    private EmployeeCredentialDto getAuthenticatedUser(WebSocketSession session) {
+        SecurityContext securityContext = (SecurityContext) session.getAttributes().get("SPRING_SECURITY_CONTEXT");
+        if (securityContext != null) {
+            Authentication authentication = securityContext.getAuthentication();
+            if (authentication != null && authentication.isAuthenticated()) {
+                return (EmployeeCredentialDto) authentication.getPrincipal();
+            }
+        }
+        return null;
+    }
+
+    // INFO : 특정 채팅방 session 저장
+    private void subscribeToChatRoom(Long userId, Long chatRoomId, WebSocketSession session) {
+        sessions.putIfAbsent(userId, new ConcurrentHashMap<>());
+        sessions.get(userId).put(chatRoomId, session);
+        log.info("User {} subscribed to chatRoom {}", userId, chatRoomId);
+    }
+
+    // INFO : 특정 채팅방 session 제거
+    private void unsubscribeFromChatRoom(Long userId, Long chatRoomId) {
+        if (sessions.containsKey(userId) && sessions.get(userId).containsKey(chatRoomId)) {
+            sessions.get(userId).remove(chatRoomId);
+            log.info("User {} unsubscribed from chatRoom {}", userId, chatRoomId);
+        }
+    }
+
+    // INFO : 특정 채팅방 session 찾는 메서드
     public WebSocketSession getSession(long employeeNo, Long roomId) {
-        return sessions.get(employeeNo).get(roomId);
+        ConcurrentHashMap<Long, WebSocketSession> session = sessions.get(employeeNo);
+        if(session == null){
+            log.info("User {} not found", employeeNo);
+            return null;
+        }
+        WebSocketSession webSocketSession = Objects.requireNonNull(session).get(roomId);
+        if(webSocketSession == null) {
+            log.info("no session");
+            return null;
+        }
+        return webSocketSession;
     }
 }

--- a/src/main/java/com/example/chulgunhazabackend/websocket/handler/WebSocketMessageHandler.java
+++ b/src/main/java/com/example/chulgunhazabackend/websocket/handler/WebSocketMessageHandler.java
@@ -1,0 +1,76 @@
+package com.example.chulgunhazabackend.websocket.handler;
+
+import com.example.chulgunhazabackend.dto.Employee.EmployeeCredentialDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+public class WebSocketMessageHandler implements WebSocketHandler {
+
+    private static final ConcurrentHashMap<Long, ConcurrentHashMap<Long, WebSocketSession>> sessions = new ConcurrentHashMap<>();
+
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+
+        // INFO : 인증된 유저의 정보를 가져와서 ConcurrentHashMap 에 저장을 합니다.
+        // HACK : 우선 웹 소캣 통신에 대한 기반을 잡아두고 Redis Session Storage 에 저장하는 로직을 작성 예정, 다만 Emitter 처럼 Redis 에 직렬화 해서 넣기가 애매 함.
+        SecurityContext securityContext = (SecurityContext) session.getAttributes().get("SPRING_SECURITY_CONTEXT");
+        if(securityContext != null) {
+            Authentication authentication = securityContext.getAuthentication();
+            if(authentication != null && authentication.isAuthenticated()) {
+                EmployeeCredentialDto credentialDto = (EmployeeCredentialDto) authentication.getPrincipal();
+                sessions.put(credentialDto.getId(), new ConcurrentHashMap<>());
+                log.info("Websocket Connected for user " + credentialDto.getId());
+            }else {
+                session.close(CloseStatus.NOT_ACCEPTABLE);
+                log.warn("Failed to connect to websocket, no Authentication");
+            }
+        }else{
+            session.close(CloseStatus.NOT_ACCEPTABLE);
+            log.warn("WebSocket connection attempt failed. SecurityContext is missing.");
+        }
+    }
+
+    @Override
+    public void handleMessage(WebSocketSession session, WebSocketMessage<?> message) throws Exception {
+        //INFO : Client 로 부터 받은 메시지를 처리할 수 있음.
+    }
+
+    @Override
+    public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
+        //INFO : Client 로 부터 받은 메시지에 에러가 발생했을 때 처리할 수 있음.
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus) throws Exception {
+        SecurityContext securityContext = (SecurityContext) session.getAttributes().get("SPRING_SECURITY_CONTEXT");
+        if (securityContext != null) {
+            Authentication authentication = securityContext.getAuthentication();
+            if (authentication != null) {
+                EmployeeCredentialDto credentialDto = (EmployeeCredentialDto) authentication.getPrincipal();
+                sessions.remove(credentialDto.getEmployeeNo()); // 세션 종료 시 제거
+                log.info("WebSocket connection closed for user: {}", credentialDto.getEmployeeNo());
+            }
+        }
+    }
+
+    @Override
+    public boolean supportsPartialMessages() {
+        return false;
+    }
+
+    public WebSocketSession getSession(long employeeNo, Long roomId) {
+        return sessions.get(employeeNo).get(roomId);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #23 #25  #35 #36 #43 

## 📝작업 내용

> 
채팅 알람 Event 처리 했습니다.
![ChatEvent](https://github.com/user-attachments/assets/7bad789b-fd6b-488d-800a-162411a16218)
![ChatEventHandler](https://github.com/user-attachments/assets/c311a5dd-928a-4fdc-87c3-e4216280fee2)

전송시간 필드 및 읽음 여부 필드 추가 했습니다.
![chatMessageDomain](https://github.com/user-attachments/assets/e4f06e3f-d190-4b7e-92da-5f578a4d631a)

기존 예외 발생 시 RMQ 에서 무한 루프 발생하여, 예외 발생 시 메시지 큐에서 제거하는 로직 추가했습니다.
![ChatMessageListener](https://github.com/user-attachments/assets/479cdff6-eda6-4f30-bdae-23f850ab0a80)

sse 구독 , 전송 하는 로직입니다. 
![ChatSubScribeAndSend](https://github.com/user-attachments/assets/c16c87d3-b321-4a0a-8b46-b5206174d03c)

기존 PathVariable 로 받아오는 방식에서 인증 유저 객체 정보를 가져오는 방식으로 변경했습니다. 
![NotificationController](https://github.com/user-attachments/assets/1159ff3d-1390-4c2d-96c6-1d25d0c88a6a)

WebSocket 구독 경로 입니다. 또한 Security 인증 객체를 사용하는 Interceptor 를 추가했습니다.
![WebSocketConfig](https://github.com/user-attachments/assets/d1813d19-ea30-45be-a355-a30d25538695)

## 💬리뷰 요구사항(선택)
추가 적인 코드는 내용이 너무 많아, 전체 첨부하지 못했습니다.
문제 발생가능한 코드들은 추후 리펙토링 예정입니다. 또한 테스트가 부족하여, 추 후 테스트 기간을 더 가지면 좋을 거 같습니다. 

